### PR TITLE
keep a reference to callback userdata

### DIFF
--- a/src/mpb_interface.jl
+++ b/src/mpb_interface.jl
@@ -280,9 +280,9 @@ function setlazycallback!(m::SCIPMathProgModel, f)
     # f is function(d::SCIPLazyCallbackData)
 
     cbfunction = cfunction(lazycb_wrapper, Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}))
-    userdata = (m, f)
+    m.lazy_userdata = (m, f)
 
-    _addLazyCallback(m, cbfunction, userdata)
+    _addLazyCallback(m, cbfunction, m.lazy_userdata)
 end
 
 # if we are called from a lazy callback, we check whether the LP relaxation is integral
@@ -351,9 +351,9 @@ function setheuristiccallback!(m::SCIPMathProgModel, f)
     # f is function(d::SCIPHeurCallbackData)
 
     cbfunction = cfunction(heurcb_wrapper, Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}))
-    userdata = (m, f)
+    m.heur_userdata = (m, f)
 
-    _addHeuristicCallback(m, cbfunction, userdata)
+    _addHeuristicCallback(m, cbfunction, m.heur_userdata)
 end
 
 # TODO: detect :MIPSol like with lazy constraints?

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,6 +5,8 @@ export SCIPSolver
 type SCIPMathProgModel <: AbstractLinearQuadraticModel
     ptr_model::Ptr{Void}
     options
+    lazy_userdata
+    heur_userdata
 
     function SCIPMathProgModel(options...)
         _arr = Array(Ptr{Void}, 1)


### PR DESCRIPTION
If we don't keep a reference on the Julia side, then the object could be freed by the GC at any time and cause nasty segfaults when we try to access it from inside the callback.