### PR TITLE
Use proper model types for LinearQuadratic and Nonlinear interfaces

### DIFF
--- a/src/mpb_interface.jl
+++ b/src/mpb_interface.jl
@@ -118,7 +118,10 @@ function setparameters!(m::SCIPMathProgModel; mpboptions...)
     end
 end
 
-
+function setwarmstart!(m::SCIPMathProgModel, v)
+    # does not support incomplete solutions (with NaN)
+    _setInitialSolution(m, float(v))
+end
 
 ###########################################################################
 ##### Methods specific to AbstractLinearQuadraticModel                #####
@@ -217,11 +220,6 @@ getunboundedray(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.j
 getsimplexiter(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
 getbarrieriter(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
-
-function setwarmstart!(m::SCIPLinearQuadraticModel, v)
-    # does not support incomplete solutions (with NaN)
-    _setInitialSolution(m, float(v))
-end
 
 ##########################################################################
 ##### Methods specific to Integer Programming                        #####

--- a/src/mpb_interface.jl
+++ b/src/mpb_interface.jl
@@ -125,10 +125,10 @@ end
 ##### see: http://mathprogbasejl.readthedocs.io/en/latest/lpqcqp.html #####
 ###########################################################################
 
-loadproblem!(m::SCIPMathProgModel, filename::AbstractString) =
+loadproblem!(m::SCIPLinearQuadraticModel, filename::AbstractString) =
     error("Not implemented for SCIP.jl")
 
-function loadproblem!(m::SCIPMathProgModel, A, varlb, varub, obj, rowlb, rowub, sense)
+function loadproblem!(m::SCIPLinearQuadraticModel, A, varlb, varub, obj, rowlb, rowub, sense)
     # TODO: clean old model?
 
     nrows, ncols = size(A)
@@ -156,69 +156,69 @@ function loadproblem!(m::SCIPMathProgModel, A, varlb, varub, obj, rowlb, rowub, 
     end
 end
 
-writeproblem(m::SCIPMathProgModel, filename::AbstractString) =
+writeproblem(m::SCIPLinearQuadraticModel, filename::AbstractString) =
     error("Not implemented for SCIP.jl")
 
-getvarLB(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getvarLB(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-function setvarLB!(m::SCIPMathProgModel, lb)
+function setvarLB!(m::SCIPLinearQuadraticModel, lb)
     indices = collect(zero(Cint):Cint(numvar(m) - 1))
     _chgVarLB(m, Cint(numvar(m)), indices, float(lb))
 end
 
-getvarUB(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getvarUB(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-function setvarUB!(m::SCIPMathProgModel, ub)
+function setvarUB!(m::SCIPLinearQuadraticModel, ub)
     indices = collect(zero(Cint):Cint(numvar(m) - 1))
     _chgVarUB(m, Cint(numvar(m)), indices, float(ub))
 end
 
-getconstrLB(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getconstrLB(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-# setconstrLB!(m::SCIPMathProgModel, lb) = error("Not implemented for SCIP.jl")
+# setconstrLB!(m::SCIPLinearQuadraticModel, lb) = error("Not implemented for SCIP.jl")
 
-getconstrUB(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getconstrUB(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-# setconstrUB!(m::SCIPMathProgModel, ub) = error("Not implemented for SCIP.jl")
+# setconstrUB!(m::SCIPLinearQuadraticModel, ub) = error("Not implemented for SCIP.jl")
 
-getobj(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getobj(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-function setobj!(m::SCIPMathProgModel, obj)
+function setobj!(m::SCIPLinearQuadraticModel, obj)
     indices = collect(zero(Cint):Cint(numvar(m) - 1))
     _setObj(m, Cint(numvar(m)), indices, float(obj))
 end
 
-getconstrmatrix(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getconstrmatrix(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-addvar!(m::SCIPMathProgModel, constridx, constrcoef, l, u, objcoef) =
+addvar!(m::SCIPLinearQuadraticModel, constridx, constrcoef, l, u, objcoef) =
     error("Not implemented for SCIP.jl")
 
-addvar!(m::SCIPMathProgModel, l, u, objcoef) = error("Not implemented for SCIP.jl")
+addvar!(m::SCIPLinearQuadraticModel, l, u, objcoef) = error("Not implemented for SCIP.jl")
 
-function addconstr!(m::SCIPMathProgModel, varidx, coef, lb, ub)
+function addconstr!(m::SCIPLinearQuadraticModel, varidx, coef, lb, ub)
     _addLinCons(m, Cint(length(varidx)), Vector{Cint}(varidx - 1), float(coef),
                 float(lb), float(ub), Ptr{Cint}(C_NULL))
 end
 
-numlinconstr(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+numlinconstr(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getconstrsolution(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getconstrsolution(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getreducedcosts(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getreducedcosts(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getconstrduals(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getconstrduals(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getinfeasibilityray(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getinfeasibilityray(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getbasis(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getbasis(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getunboundedray(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getunboundedray(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getsimplexiter(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getsimplexiter(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getbarrieriter(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getbarrieriter(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-function setwarmstart!(m::SCIPMathProgModel, v)
+function setwarmstart!(m::SCIPLinearQuadraticModel, v)
     # does not support incomplete solutions (with NaN)
     _setInitialSolution(m, float(v))
 end
@@ -227,15 +227,15 @@ end
 ##### Methods specific to Integer Programming                        #####
 ##########################################################################
 
-getnodecount(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getnodecount(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-function addsos1!(m::SCIPMathProgModel, idx, weight)
+function addsos1!(m::SCIPLinearQuadraticModel, idx, weight)
     nidx = Cint(length(idx))
     cidx = convert(Vector{Cint}, idx - 1)
     _addSOS1(m, nidx, cidx, weight, Ptr{Cint}(C_NULL))
 end
 
-function addsos2!(m::SCIPMathProgModel, idx, weight)
+function addsos2!(m::SCIPLinearQuadraticModel, idx, weight)
     nidx = Cint(length(idx))
     cidx = convert(Vector{Cint}, idx - 1)
     _addSOS2(m, nidx, cidx, weight, Ptr{Cint}(C_NULL))
@@ -245,20 +245,20 @@ end
 ##### Methods specific to Quadratic Programming                      #####
 ##########################################################################
 
-numquadconstr(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+numquadconstr(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-setquadobj!{T<:Real}(m::SCIPMathProgModel, Q::Array{T, 2}) =
+setquadobj!{T<:Real}(m::SCIPLinearQuadraticModel, Q::Array{T, 2}) =
     error("Not implemented for SCIP.jl")
 
-setquadobj!(m::SCIPMathProgModel, rowidx, colidx, quadval) =
+setquadobj!(m::SCIPLinearQuadraticModel, rowidx, colidx, quadval) =
     error("Not implemented for SCIP.jl")
 
-setquadobjterms!(m::SCIPMathProgModel, rowidx, colidx, quadval) =
+setquadobjterms!(m::SCIPLinearQuadraticModel, rowidx, colidx, quadval) =
     _setQuadObj(m, Cint(0), Array{Cint}(0), Array{Cdouble}(0),
                  Cint(length(rowidx)), convert(Vector{Cint}, rowidx - 1),
                  convert(Vector{Cint}, colidx - 1), quadval)
 
-function addquadconstr!(m::SCIPMathProgModel, linearidx, linearval, quadrowidx, quadcolidx, quadval, sense, rhs)
+function addquadconstr!(m::SCIPLinearQuadraticModel, linearidx, linearval, quadrowidx, quadcolidx, quadval, sense, rhs)
     clhs = -Inf
     crhs =  Inf
     if sense == '<'
@@ -275,15 +275,15 @@ function addquadconstr!(m::SCIPMathProgModel, linearidx, linearval, quadrowidx, 
                  convert(Vector{Cint}, quadcolidx - 1), quadval, clhs, crhs, Ptr{Cint}(C_NULL))
 end
 
-getquadconstrsolution(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getquadconstrsolution(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getquadconstrduals(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getquadconstrduals(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getquadinfeasibilityray(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getquadinfeasibilityray(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-getquadconstrRHS(m::SCIPMathProgModel) = error("Not implemented for SCIP.jl")
+getquadconstrRHS(m::SCIPLinearQuadraticModel) = error("Not implemented for SCIP.jl")
 
-setquadconstrRHS!(m::SCIPMathProgModel, lb) = error("Not implemented for SCIP.jl")
+setquadconstrRHS!(m::SCIPLinearQuadraticModel, lb) = error("Not implemented for SCIP.jl")
 
 ##########################################################################
 ##### Methods specific to MIP Callbacks                              #####
@@ -315,9 +315,9 @@ function setlazycallback!(m::SCIPMathProgModel, f)
     # f is function(d::SCIPLazyCallbackData)
 
     cbfunction = cfunction(lazycb_wrapper, Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}))
-    m.lazy_userdata = (m, f)
+    m.inner.lazy_userdata = (m, f)
 
-    _addLazyCallback(m, cbfunction, m.lazy_userdata)
+    _addLazyCallback(m, cbfunction, m.inner.lazy_userdata)
 end
 
 # if we are called from a lazy callback, we check whether the LP relaxation is integral
@@ -386,9 +386,9 @@ function setheuristiccallback!(m::SCIPMathProgModel, f)
     # f is function(d::SCIPHeurCallbackData)
 
     cbfunction = cfunction(heurcb_wrapper, Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}))
-    m.heur_userdata = (m, f)
+    m.inner.heur_userdata = (m, f)
 
-    _addHeuristicCallback(m, cbfunction, m.heur_userdata)
+    _addHeuristicCallback(m, cbfunction, m.inner.heur_userdata)
 end
 
 # TODO: detect :MIPSol like with lazy constraints?
@@ -518,7 +518,7 @@ end
 # the AbstractNLPEvaluator contains the constraints and objective.
 # One can get different data from it (with initialize)
 # SCIP doesn't need most of the data, just the epression
-function loadproblem!(m::SCIPMathProgModel, numVars, numConstr,
+function loadproblem!(m::SCIPNonlinearModel, numVars, numConstr,
                       l, u, lb, ub, sense, d::AbstractNLPEvaluator)
     # add variables
     for v in 1:numVars

--- a/src/params.jl
+++ b/src/params.jl
@@ -5,7 +5,7 @@
 # the code is horrible doing this zip between names (odd positions) and values (even positions)
 # since options look like: "param1", value1, "param2", value2, ...
 function setparams!(m::SCIPMathProgModel)
-    a = m.options
+    a = m.inner.options
     for (name, value) in zip(a[1][1:2:end],a[1][2:2:end])
         setparameter!(m, name, value)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,14 +1,14 @@
 export SCIPSolver
 
-# Linear Quadratic Model
+# Common inner model
 
-type SCIPMathProgModel <: AbstractLinearQuadraticModel
+type SCIPModel
     ptr_model::Ptr{Void}
     options
     lazy_userdata
     heur_userdata
 
-    function SCIPMathProgModel(options...)
+    function SCIPModel(options...)
         _arr = Array(Ptr{Void}, 1)
         # TODO: check return code (everywhere!)
         ccall((:CSIPcreateModel, libcsip), Cint, (Ptr{Ptr{Void}}, ), _arr)
@@ -19,17 +19,34 @@ type SCIPMathProgModel <: AbstractLinearQuadraticModel
     end
 end
 
+# Linear Quadratic Model
+
+type SCIPLinearQuadraticModel <: AbstractLinearQuadraticModel
+    inner::SCIPModel
+end
+
 # Nonlinear Model
 
 type SCIPNonlinearModel <: AbstractNonlinearModel
-    m::SCIPMathProgModel
+    inner::SCIPModel
 end
+
+# Union type for common behaviour
+
+SCIPMathProgModel = Union{SCIPLinearQuadraticModel, SCIPNonlinearModel}
 
 # Solver
 
 type SCIPSolver <: AbstractMathProgSolver
     options
 end
+
 SCIPSolver(kwargs...) = SCIPSolver(kwargs)
-LinearQuadraticModel(s::SCIPSolver) = SCIPMathProgModel(s.options)
-NonlinearModel(s::SCIPSolver) = SCIPMathProgModel(s.options)
+
+function LinearQuadraticModel(s::SCIPSolver)
+    SCIPLinearQuadraticModel(SCIPMathProgModel(s.options))
+end
+
+function NonlinearModel(s::SCIPSolver)
+    SCIPNonlinearModel(SCIPMathProgModel(s.options))
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -14,7 +14,6 @@ type SCIPModel
         ccall((:CSIPcreateModel, libcsip), Cint, (Ptr{Ptr{Void}}, ), _arr)
         m = new(_arr[1], options)
         # QUESTION: Why is _arr not garbage-collected?
-        setparams!(m)
         return m
     end
 end
@@ -44,9 +43,13 @@ end
 SCIPSolver(kwargs...) = SCIPSolver(kwargs)
 
 function LinearQuadraticModel(s::SCIPSolver)
-    SCIPLinearQuadraticModel(SCIPModel(s.options))
+    m = SCIPLinearQuadraticModel(SCIPModel(s.options))
+    setparams!(m)
+    m
 end
 
 function NonlinearModel(s::SCIPSolver)
-    SCIPNonlinearModel(SCIPModel(s.options))
+    m = SCIPNonlinearModel(SCIPModel(s.options))
+    setparams!(m)
+    m
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -44,9 +44,9 @@ end
 SCIPSolver(kwargs...) = SCIPSolver(kwargs)
 
 function LinearQuadraticModel(s::SCIPSolver)
-    SCIPLinearQuadraticModel(SCIPMathProgModel(s.options))
+    SCIPLinearQuadraticModel(SCIPModel(s.options))
 end
 
 function NonlinearModel(s::SCIPSolver)
-    SCIPNonlinearModel(SCIPMathProgModel(s.options))
+    SCIPNonlinearModel(SCIPModel(s.options))
 end

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -11,40 +11,40 @@ function _patchVersion()
 end
 
 function _freeModel(model::SCIPMathProgModel)
-    ccall((:CSIPfreeModel, libcsip), Cint, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPfreeModel, libcsip), Cint, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _addVar(model::SCIPMathProgModel, lowerbound::Cdouble,
                  upperbound::Cdouble, vartype::Cint, idx::Ptr{Cint})
     ccall((:CSIPaddVar, libcsip), Cint,
           (Ptr{Void}, Cdouble, Cdouble, Cint, Ptr{Cint}),
-          model.ptr_model, lowerbound, upperbound, vartype, idx)
+          model.inner.ptr_model, lowerbound, upperbound, vartype, idx)
 end
 
 function _chgVarLB(model::SCIPMathProgModel, numindices::Cint,
                    indices::Vector{Cint}, lowerbounds::Vector{Cdouble})
     ccall((:CSIPchgVarLB, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cdouble}),
-          model.ptr_model, numindices, indices, lowerbounds)
+          model.inner.ptr_model, numindices, indices, lowerbounds)
 end
 
 function _chgVarUB(model::SCIPMathProgModel, numindices::Cint,
                    indices::Vector{Cint}, upperbounds::Vector{Cdouble})
     ccall((:CSIPchgVarUB, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cdouble}),
-          model.ptr_model, numindices, indices, upperbounds)
+          model.inner.ptr_model, numindices, indices, upperbounds)
 end
 
 function _getVarType(model::SCIPMathProgModel, varindex::Cint)
     ccall((:CSIPgetVarType, libcsip), Cint,
           (Ptr{Void}, Cint),
-          model.ptr_model, varindex)
+          model.inner.ptr_model, varindex)
 end
 
 function _chgVarType(model::SCIPMathProgModel, varindex::Cint, vartype::Cint)
     ccall((:CSIPchgVarType, libcsip), Cint,
           (Ptr{Void}, Cint, Cint),
-          model.ptr_model, varindex, vartype)
+          model.inner.ptr_model, varindex, vartype)
 end
 
 function _addLinCons(model::SCIPMathProgModel, numindices::Cint,
@@ -52,7 +52,7 @@ function _addLinCons(model::SCIPMathProgModel, numindices::Cint,
                      lhs::Cdouble, rhs::Cdouble, idx::Ptr{Cint})
     ccall((:CSIPaddLinCons, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cdouble, Cdouble, Ptr{Cint}),
-          model.ptr_model, numindices, indices, coefs, lhs, rhs, idx)
+          model.inner.ptr_model, numindices, indices, coefs, lhs, rhs, idx)
 end
 
 function _addQuadCons(model::SCIPMathProgModel, numlinindices::Cint,
@@ -63,7 +63,7 @@ function _addQuadCons(model::SCIPMathProgModel, numlinindices::Cint,
     ccall((:CSIPaddQuadCons, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}, Ptr{Cint},
            Ptr{Cdouble}, Cdouble, Cdouble, Ptr{Cint}),
-          model.ptr_model, numlinindices, linindices, lincoefs, numquadterms,
+          model.inner.ptr_model, numlinindices, linindices, lincoefs, numquadterms,
           quadrowindices, quadcolindices, quadcoefs, lhs, rhs, idx)
 end
 
@@ -73,7 +73,7 @@ function _addNonLinCons(model::SCIPMathProgModel, nops::Cint,
                      lhs::Cdouble, rhs::Cdouble, idx::Ptr{Cint})
     ccall((:CSIPaddNonLinCons, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}, Cdouble, Cdouble, Ptr{Cint}),
-          model.ptr_model, nops, ops, children, beg, values, lhs, rhs, idx)
+          model.inner.ptr_model, nops, ops, children, beg, values, lhs, rhs, idx)
 end
 
 function _addSOS1(model::SCIPMathProgModel, numindices::Cint,
@@ -81,7 +81,7 @@ function _addSOS1(model::SCIPMathProgModel, numindices::Cint,
                   idx::Ptr{Cint})
     ccall((:CSIPaddSOS1, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-          model.ptr_model, numindices, indices, weights, idx)
+          model.inner.ptr_model, numindices, indices, weights, idx)
 end
 
 function _addSOS2(model::SCIPMathProgModel, numindices::Cint,
@@ -89,14 +89,14 @@ function _addSOS2(model::SCIPMathProgModel, numindices::Cint,
                   idx::Ptr{Cint})
     ccall((:CSIPaddSOS2, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cdouble}, Ptr{Cint}),
-          model.ptr_model, numindices, indices, weights, idx)
+          model.inner.ptr_model, numindices, indices, weights, idx)
 end
 
 function _setObj(model::SCIPMathProgModel, numindices::Cint,
                  indices::Vector{Cint}, coefs::Vector{Cdouble})
     ccall((:CSIPsetObj, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cdouble}),
-          model.ptr_model, numindices, indices, coefs)
+          model.inner.ptr_model, numindices, indices, coefs)
 end
 
 function _setQuadObj(model::SCIPMathProgModel, numlinindices::Cint,
@@ -106,7 +106,7 @@ function _setQuadObj(model::SCIPMathProgModel, numlinindices::Cint,
     ccall((:CSIPsetQuadObj, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cdouble}, Cint, Ptr{Cint}, Ptr{Cint},
            Ptr{Cdouble}),
-          model.ptr_model, numlinindices, linindices, lincoefs, numquadterms,
+          model.inner.ptr_model, numlinindices, linindices, lincoefs, numquadterms,
           quadrowindices, quadcolindices, quadcoefs)
 end
 
@@ -115,101 +115,101 @@ function _setNonlinearObj(model::SCIPMathProgModel, nops::Cint,
                           beg::Vector{Cint}, values::Vector{Cdouble})
     ccall((:CSIPsetNonlinearObj, libcsip), Cint,
           (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
-          model.ptr_model, nops, ops, children, beg, values)
+          model.inner.ptr_model, nops, ops, children, beg, values)
 end
 
 function _setSenseMinimize(model::SCIPMathProgModel)
-    ccall((:CSIPsetSenseMinimize, libcsip), Cint, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPsetSenseMinimize, libcsip), Cint, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _setSenseMaximize(model::SCIPMathProgModel)
-    ccall((:CSIPsetSenseMaximize, libcsip), Cint, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPsetSenseMaximize, libcsip), Cint, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _solve(model::SCIPMathProgModel)
-    ccall((:CSIPsolve, libcsip), Cint, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPsolve, libcsip), Cint, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _interrupt(model::SCIPMathProgModel)
-    ccall((:CSIPinterrupt, libcsip), Cint, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPinterrupt, libcsip), Cint, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _getVarValues(model::SCIPMathProgModel, output::Vector{Cdouble})
     ccall((:CSIPgetVarValues, libcsip), Cint, (Ptr{Void}, Ptr{Cdouble}),
-          model.ptr_model, output)
+          model.inner.ptr_model, output)
 end
 
 function _getObjValue(model::SCIPMathProgModel)
-    ccall((:CSIPgetObjValue, libcsip), Cdouble, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPgetObjValue, libcsip), Cdouble, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _getObjBound(model::SCIPMathProgModel)
-    ccall((:CSIPgetObjBound, libcsip), Cdouble, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPgetObjBound, libcsip), Cdouble, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _getStatus(model::SCIPMathProgModel)
-    ccall((:CSIPgetStatus, libcsip), Cint, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPgetStatus, libcsip), Cint, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _getParamType(model::SCIPMathProgModel, name::Ptr{UInt8})
     ccall((:CSIPgetParamType, libcsip), Cint,
           (Ptr{Void}, Ptr{UInt8}),
-          model.ptr_model, name)
+          model.inner.ptr_model, name)
 end
 
 function _setBoolParam(model::SCIPMathProgModel, name::Ptr{UInt8},
                               value::Cint)
     ccall((:CSIPsetBoolParam, libcsip), Cint,
           (Ptr{Void}, Ptr{UInt8}, Cint),
-          model.ptr_model, name, value)
+          model.inner.ptr_model, name, value)
 end
 
 function _setIntParam(model::SCIPMathProgModel, name::Ptr{UInt8},
                               value::Cint)
     ccall((:CSIPsetIntParam, libcsip), Cint,
           (Ptr{Void}, Ptr{UInt8}, Cint),
-          model.ptr_model, name, value)
+          model.inner.ptr_model, name, value)
 end
 
 function _setLongintParam(model::SCIPMathProgModel, name::Ptr{UInt8},
                               value::Clonglong)
     ccall((:CSIPsetLongintParam, libcsip), Cint,
           (Ptr{Void}, Ptr{UInt8}, Clonglong),
-          model.ptr_model, name, value)
+          model.inner.ptr_model, name, value)
 end
 
 function _setRealParam(model::SCIPMathProgModel, name::Ptr{UInt8},
                               value::Cdouble)
     ccall((:CSIPsetRealParam, libcsip), Cint,
           (Ptr{Void}, Ptr{UInt8}, Cdouble),
-          model.ptr_model, name, value)
+          model.inner.ptr_model, name, value)
 end
 
 function _setCharParam(model::SCIPMathProgModel, name::Ptr{UInt8},
                               value::Cchar)
     ccall((:CSIPsetCharParam, libcsip), Cint,
           (Ptr{Void}, Ptr{UInt8}, Cchar),
-          model.ptr_model, name, value)
+          model.inner.ptr_model, name, value)
 end
 
 function _setStringParam(model::SCIPMathProgModel, name::Ptr{UInt8},
                          value::Ptr{UInt8})
     ccall((:CSIPsetStringParam, libcsip), Cint,
           (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}),
-          model.ptr_model, name, value)
+          model.inner.ptr_model, name, value)
 end
 
 function _getNumVars(model::SCIPMathProgModel)
-    ccall((:CSIPgetNumVars, libcsip), Cint, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPgetNumVars, libcsip), Cint, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _getNumConss(model::SCIPMathProgModel)
-    ccall((:CSIPgetNumConss, libcsip), Cint, (Ptr{Void}, ), model.ptr_model)
+    ccall((:CSIPgetNumConss, libcsip), Cint, (Ptr{Void}, ), model.inner.ptr_model)
 end
 
 function _setInitialSolution(model::SCIPMathProgModel, values::Vector{Cdouble})
     ccall((:CSIPsetInitialSolution, libcsip), Cint, (Ptr{Void}, Ptr{Cdouble}),
-          model.ptr_model, values)
+          model.inner.ptr_model, values)
 end
 
 function _lazyGetContext(lazydata::Ptr{Void})
@@ -232,7 +232,7 @@ end
 function _addLazyCallback(model::SCIPMathProgModel, lazycb::Ptr{Void}, userdata)
     ccall((:CSIPaddLazyCallback, libcsip), Cint,
           (Ptr{Void}, Ptr{Void}, Any),
-          model.ptr_model, lazycb, userdata)
+          model.inner.ptr_model, lazycb, userdata)
 end
 
 function _heurGetVarValues(heurdata::Ptr{Void}, output::Vector{Cdouble})
@@ -247,10 +247,10 @@ end
 
 function _addHeuristicCallback(model::SCIPMathProgModel, heur::Ptr{Void}, userdata)
     ccall((:CSIPaddHeuristicCallback, libcsip), Cint, (Ptr{Void}, Ptr{Void}, Any),
-          model.ptr_model, heur, userdata)
+          model.inner.ptr_model, heur, userdata)
 end
 
 function _getInternalSCIP(model::SCIPMathProgModel)
     ccall((:CSIPgetInternalSCIP, libcsip), Ptr{Void}, (Ptr{Void}, ),
-          model.ptr_model)
+          model.inner.ptr_model)
 end


### PR DESCRIPTION
I added two wrapper types and used the more specific method signatures, according to the MathProgBase documentation. For the common methods, I created a union type.

Related to discussion in #26.
