### PR TITLE
Elaborated installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Next set the **environment variable `SCIPOPTDIR`** to point to the directory tha
 
 ```
 export SCIPOPTDIR=/path/to/scipoptdirsuite/sources
-*For example:* export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
+Example: export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
 ```
 CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 

--- a/README.md
+++ b/README.md
@@ -23,21 +23,22 @@ Julia interface to [SCIP](http://scip.zib.de) solver.
 The SCIP.jl package requires SCIP to be installed.
 
 [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the
-SCIP Optimization Suite, copy the
-[patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
-and build the shared library with
+SCIP Optimization Suite and build the shared library with
+
 ```
 make SHARED=true GMP=false READLINE=false ZLIB=false OPT=opt scipoptlib
 ```
 
-Next set the environment variable `SCIPOPTDIR` to point to the directory that
-contains the `scipoptsuite` sources. CSIP needs the library in
-`${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in
-`${SCIPOPTDIR}/scip-*/src/`.
+Next set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. 
 
-Now you should be able to build SCIP.jl in Julia with
+CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
+
+Clone the SCIP repository in your local machine and build it in Julia with
+
 ```
+Pkg.clone("https://github.com/SCIP-Interfaces/SCIP.jl.git")
 Pkg.build("SCIP")
+
 ```
 
 ## Setting Parameters

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Next set the **environment variable `SCIPOPTDIR`** to point to the directory tha
 
 ```
 export SCIPOPTDIR=/path/to/scipoptdirsuite/sources
-For example: export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
+*For example:* export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
 ```
 CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 

--- a/README.md
+++ b/README.md
@@ -22,30 +22,26 @@ Julia interface to [SCIP](http://scip.zib.de) solver.
 
 Follow the steps below to get SCIP.jl working
 
-The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed. [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the SCIP Optimization Suite, untar it.
-
+1. The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed. [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the SCIP Optimization Suite, untar it.
 ```
 wget http://scip.zib.de/download/release/scipoptsuite-3.2.1.tgz
 tar xzf scipoptsuite-3.2.1.tgz
 ```
-
-Replace the existing `Makefile.doit` with the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
+2. Replace the existing `Makefile.doit` with the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
 ```
 cd scipoptsuite-3.2.1/
 rm Makefile.doit
 wget http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit
 ```
-Build the shared library with
+3. Build the shared library with
 ```
 make SHARED=true GMP=false READLINE=false ZLIB=false scipoptlib
 ```
-
-Set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
+4. Set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 ```
 export SCIPOPTDIR=`pwd`
 ```
-
-This package is registered in `METADATA.jl` and can be installed in Julia with
+5. This package is registered in `METADATA.jl` and can be installed in Julia with
 ```
 Pkg.add("SCIP")
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Julia interface to [SCIP](http://scip.zib.de) solver.
 
 Follow the steps below to get SCIP.jl working
 
-1.The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed. [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the SCIP Optimization Suite, untar it.
+1. The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed. [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the SCIP Optimization Suite, untar it.
 
 ```
 wget http://scip.zib.de/download/release/scipoptsuite-3.2.1.tgz
@@ -34,7 +34,7 @@ tar xzf scipoptsuite-3.2.1.tgz
 cd scipoptsuite-3.2.1/
 rm Makefile.doit
 wget http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit
-
+```
 3. Build the shared library with
 ```
 make SHARED=true GMP=false READLINE=false ZLIB=false scipoptlib

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Julia interface to [SCIP](http://scip.zib.de) solver.
 
 ## Installation
 
-The SCIP.jl package requires SCIP to be installed.
+The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed.
 
 [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the
 SCIP Optimization Suite and build the shared library with
@@ -30,15 +30,17 @@ make SHARED=true GMP=false READLINE=false ZLIB=false OPT=opt scipoptlib
 ```
 
 Next set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. 
+```
+export SCIPOPTDIR=/path/to/scipoptdirsuite/directory
 
+```
 CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 
-Clone the SCIP repository in your local machine and build it in Julia with
+Clone the SCIP github repository in your local machine and build it in Julia with
 
 ```
 Pkg.clone("https://github.com/SCIP-Interfaces/SCIP.jl.git")
 Pkg.build("SCIP")
-
 ```
 
 ## Setting Parameters

--- a/README.md
+++ b/README.md
@@ -20,25 +20,32 @@ Julia interface to [SCIP](http://scip.zib.de) solver.
 
 ## Installation
 
-The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed.
+Follow the steps below to get SCIP.jl working
 
-[Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the
-SCIP Optimization Suite, untar it and, build the shared library with
-
-```
-make SHARED=true GMP=false READLINE=false ZLIB=false OPT=opt scipoptlib
-```
-
-Next set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. 
+1.The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed. [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the SCIP Optimization Suite, untar it.
 
 ```
-export SCIPOPTDIR=/path/to/scipoptdirsuite
-Example: export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
+wget http://scip.zib.de/download/release/scipoptsuite-3.2.1.tgz
+tar xzf scipoptsuite-3.2.1.tgz
 ```
-CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 
-This package is registered in `METADATA.jl` and can be installed as usual
+2. Replace the existing `Makefile.doit` and with the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
+```
+cd scipoptsuite-3.2.1/
+rm Makefile.doit
+wget http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit
 
+3. Build the shared library with
+```
+make SHARED=true GMP=false READLINE=false ZLIB=false scipoptlib
+```
+
+4. Set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
+```
+export SCIPOPTDIR=`pwd`
+```
+
+5. This package is registered in `METADATA.jl` and can be installed in Julia with
 ```
 Pkg.add"SCIP")
 ```

--- a/README.md
+++ b/README.md
@@ -22,26 +22,26 @@ Julia interface to [SCIP](http://scip.zib.de) solver.
 
 Follow the steps below to get SCIP.jl working
 
-1. The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed. [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the SCIP Optimization Suite, untar it.
+1.The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed. [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the SCIP Optimization Suite, untar it.
 ```
 wget http://scip.zib.de/download/release/scipoptsuite-3.2.1.tgz
 tar xzf scipoptsuite-3.2.1.tgz
 ```
-2. Replace the existing `Makefile.doit` with the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
+2.Replace the existing `Makefile.doit` with the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
 ```
 cd scipoptsuite-3.2.1/
 rm Makefile.doit
 wget http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit
 ```
-3. Build the shared library with
+3.Build the shared library with
 ```
 make SHARED=true GMP=false READLINE=false ZLIB=false scipoptlib
 ```
-4. Set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
+4.Set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 ```
 export SCIPOPTDIR=`pwd`
 ```
-5. This package is registered in `METADATA.jl` and can be installed in Julia with
+5.This package is registered in `METADATA.jl` and can be installed in Julia with
 ```
 Pkg.add("SCIP")
 ```

--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ Julia interface to [SCIP](http://scip.zib.de) solver.
 The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed.
 
 [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the
-SCIP Optimization Suite and build the shared library with
+SCIP Optimization Suite, untar it and, build the shared library with
 
 ```
 make SHARED=true GMP=false READLINE=false ZLIB=false OPT=opt scipoptlib
 ```
 
 Next set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. 
-```
-export SCIPOPTDIR=/path/to/scipoptdirsuite/directory
+``
+export SCIPOPTDIR=/path/to/scipoptdirsuite/sources
+For example
+export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
 ```
 CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,10 @@ Example: export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
 ```
 CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 
-Clone the SCIP github repository in your local machine and build it in Julia with
+This package is registered in `METADATA.jl` and can be installed as usual
 
 ```
-Pkg.clone("https://github.com/SCIP-Interfaces/SCIP.jl.git")
-Pkg.build("SCIP")
+Pkg.add"SCIP")
 ```
 
 ## Setting Parameters

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ make SHARED=true GMP=false READLINE=false ZLIB=false OPT=opt scipoptlib
 ```
 
 Next set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. 
-``
+
+```
 export SCIPOPTDIR=/path/to/scipoptdirsuite/sources
 For example
 export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ wget http://scip.zib.de/download/release/scipoptsuite-3.2.1.tgz
 tar xzf scipoptsuite-3.2.1.tgz
 ```
 
-Replace the existing `Makefile.doit` and with the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
+Replace the existing `Makefile.doit` with the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
 ```
 cd scipoptsuite-3.2.1/
 rm Makefile.doit

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Next set the **environment variable `SCIPOPTDIR`** to point to the directory tha
 
 ```
 export SCIPOPTDIR=/path/to/scipoptdirsuite/sources
-For example
-export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
+For example: export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
 ```
 CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ make SHARED=true GMP=false READLINE=false ZLIB=false OPT=opt scipoptlib
 Next set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. 
 ```
 export SCIPOPTDIR=/path/to/scipoptdirsuite/directory
-
 ```
 CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 

--- a/README.md
+++ b/README.md
@@ -22,32 +22,32 @@ Julia interface to [SCIP](http://scip.zib.de) solver.
 
 Follow the steps below to get SCIP.jl working
 
-1. The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed. [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the SCIP Optimization Suite, untar it.
+The SCIP.jl package requires [SCIP](http://scip.zib.de/) to be installed. [Download](http://scip.zib.de/download.php?fname=scipoptsuite-3.2.1.tgz) the SCIP Optimization Suite, untar it.
 
 ```
 wget http://scip.zib.de/download/release/scipoptsuite-3.2.1.tgz
 tar xzf scipoptsuite-3.2.1.tgz
 ```
 
-2. Replace the existing `Makefile.doit` and with the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
+Replace the existing `Makefile.doit` and with the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit)
 ```
 cd scipoptsuite-3.2.1/
 rm Makefile.doit
 wget http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit
 ```
-3. Build the shared library with
+Build the shared library with
 ```
 make SHARED=true GMP=false READLINE=false ZLIB=false scipoptlib
 ```
 
-4. Set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
+Set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 ```
 export SCIPOPTDIR=`pwd`
 ```
 
-5. This package is registered in `METADATA.jl` and can be installed in Julia with
+This package is registered in `METADATA.jl` and can be installed in Julia with
 ```
-Pkg.add"SCIP")
+Pkg.add("SCIP")
 ```
 
 ## Setting Parameters

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make SHARED=true GMP=false READLINE=false ZLIB=false OPT=opt scipoptlib
 Next set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. 
 
 ```
-export SCIPOPTDIR=/path/to/scipoptdirsuite/sources
+export SCIPOPTDIR=/path/to/scipoptdirsuite
 Example: export SCIPOPTDIR=/home/hduser/Downloads/scipoptsuite-3.2.1
 ```
 CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.


### PR DESCRIPTION
Hi,
I had the relatively tough time trying to get SCIP.jl working. This attempt is to make installing SCIP.jl easier for people who don't understand how to set ENV variables and including missing steps during installation. Also I got SCIP.jl working without copying the [patched file](http://scip.zib.de/download/bugfixes/scip-3.2.1/Makefile.doit), I think this step is no longer required.