### PR TITLE
Update bounds for MathProgBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
 BinDeps
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7
 Compat 0.8.6

--- a/src/mpb_interface.jl
+++ b/src/mpb_interface.jl
@@ -456,12 +456,12 @@ function constr_expr_to_nodedata(ex::Expr)
     values = Float64[]
     csipex = CSIPNodeData[]
 
-    # a ex.args is [side, comp, expr, comp, side] or [expr, comp, side]
+    # a ex.args is [side, comp, expr, comp, side] or [comp, expr, side]
     if length(ex.args) == 5 # two sided constraint
         expr_to_csip(ex.args[3], values, csipex)
     else
         @assert length(ex.args) == 3
-        expr_to_csip(ex.args[1], values, csipex)
+        expr_to_csip(ex.args[2], values, csipex)
     end
     return csipex, values
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,3 @@
-JuMP
+JuMP 0.16
 GLPKMathProgInterface
 FactCheck


### PR DESCRIPTION
Enables SCIP to work with JuMP 0.16. Good idea to release a new version following this.