### PR TITLE
Ck/mac patch 400 xcode82

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ notifications:
   email: false
 sudo: required
 dist: trusty
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                   ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc              ; fi
+
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - tar xzf scipoptsuite-4.0.0.tgz
   - cd scipoptsuite-4.0.0/
   - make SHARED=true GMP=false READLINE=false ZLIB=false scipoptlib
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then g++ -install_name @rpath/libscipopt.dylib -dynamiclib -undefined suppress -flat_namespace -m64 -shared -o lib/libscipopt.dylib obj/*.o scip-*/obj/*/lib/objscip/*.o soplex-*/obj/*/lib/*o          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then g++ -install_name @rpath/libscipopt.dylib -dynamiclib -undefined suppress -flat_namespace -m64 -shared -o lib/libscipopt.dylib scip-*/obj/shared/O.darwin.x86_64.gnu.opt/lib/*/*.o soplex-*/obj/O.darwin.x86_64.gnu.opt/lib/*o          ; fi
   - export SCIPOPTDIR=`pwd`
   - cd ..
   - julia -e 'Pkg.build("SCIP"); Pkg.test("SCIP"; coverage=true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,7 @@ notifications:
   email: false
 sudo: required
 dist: trusty
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                   ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc              ; fi
-
+osx_image: xcode8.2
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd())'

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ tar xzf scipoptsuite-4.0.0.tgz
 ```
 make SHARED=true GMP=false READLINE=false ZLIB=false scipoptlib
 ```
-**An additional step for macOS users:** 
+**An additional step for macOS users:**
 ```
-g++ -install_name @rpath/libscipopt.dylib -dynamiclib -undefined suppress -flat_namespace -m64 -shared -o lib/libscipopt.dylib obj/*.o scip-*/obj/*/lib/objscip/*.o soplex-*/obj/*/lib/*o
+g++ -install_name @rpath/libscipopt.dylib -dynamiclib -undefined suppress -flat_namespace -m64 -shared -o lib/libscipopt.dylib scip-*/obj/shared/O.darwin.x86_64.gnu.opt/lib/*/*.o soplex-*/obj/O.darwin.x86_64.gnu.opt/lib/*o
 ```
 3.Set the **environment variable `SCIPOPTDIR`** to point to the directory that contains the `scipoptsuite` sources. CSIP needs the library in `${SCIPOPTDIR}/lib/scipoptlib.so` and the C header files in `${SCIPOPTDIR}/scip-*/src/`.
 ```


### PR DESCRIPTION
`more_test.jl` fails both in my local machine and in travis.

```
INFO: Testing SCIP
signal (11): Segmentation fault: 11
while loading /Users/travis/.julia/v0.5/SCIP/test/more_tests.jl, in expression starting on line 2
_ZN6soplex9CLUFactor8remaxRowEii at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN6soplex9CLUFactor12forestUpdateEiPdiPi at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN6soplex9SLUFactor6changeEiRKNS_11SVectorBaseIdEEPKNS_12SSVectorBaseIdEE at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN6soplex8SPxBasis6changeEiRNS_5SPxIdEPKNS_11SVectorBaseIdEEPKNS_12SSVectorBaseIdEE at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN6soplex9SPxSolver5leaveEib at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN6soplex9SPxSolver5solveEv at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN6soplex6SoPlex31_solveRealLPAndRecordStatisticsEv at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN6soplex6SoPlex23_preprocessAndSolveRealEb at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN6soplex6SoPlex13_optimizeRealEv at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN6soplex6SoPlex8optimizeEv at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZN7SPxSCIP8trySolveEb at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
_ZL8spxSolveP8SCIP_LPi at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
lpAlgorithm at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
lpSolveStable at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
lpSolve at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
SCIPlpSolveAndEval at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
propAndSolve at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
SCIPsolveCIP at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
SCIPsolve at /Users/travis/build/chkwon/SCIP.jl/scipoptsuite-4.0.0/lib/libscipopt.dylib (unknown line)
CSIPsolve at /Users/travis/.julia/v0.5/SCIP/deps/usr/lib/libcsip.dylib (unknown line)
_solve at /Users/travis/.julia/v0.5/SCIP/src/wrapper.jl:130
optimize! at /Users/travis/.julia/v0.5/SCIP/src/mpb_interface.jl:59
macro expansion; at /Users/travis/.julia/v0.5/SCIP/test/more_tests.jl:17 [inlined]
macro expansion; at ./test.jl:674 [inlined]
anonymous at ./<missing> (unknown line)
unknown function (ip: 0x3198b4bbf)
jl_call_method_internal at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/./julia_internal.h:210 [inlined]
jl_toplevel_eval_flex at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:569
jl_parse_eval_all at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/ast.c:717
jl_load at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:596 [inlined]
jl_load_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:605
include_from_node1 at ./loading.jl:488
jlcall_include_from_node1_20312 at /Users/travis/julia/lib/julia/sys.dylib (unknown line)
jl_call_method_internal at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/./julia_internal.h:210 [inlined]
jl_apply_generic at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/gf.c:1950
do_call at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/interpreter.c:66
eval at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/interpreter.c:190
jl_toplevel_eval_flex at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:558
jl_parse_eval_all at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/ast.c:717
jl_load at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:596 [inlined]
jl_load_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:605
include_from_node1 at ./loading.jl:488
jlcall_include_from_node1_20312 at /Users/travis/julia/lib/julia/sys.dylib (unknown line)
jl_call_method_internal at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/./julia_internal.h:210 [inlined]
jl_apply_generic at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/gf.c:1950
process_options at ./client.jl:265
_start at ./client.jl:321
jlcall__start_21657 at /Users/travis/julia/lib/julia/sys.dylib (unknown line)
jl_call_method_internal at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/./julia_internal.h:210 [inlined]
jl_apply_generic at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/gf.c:1950
true_main at /Users/travis/julia/bin/julia (unknown line)
main at /Users/travis/julia/bin/julia (unknown line)
Allocations: 1802498 (Pool: 1801559; Big: 939); GC: 0
================================[ ERROR: SCIP ]=================================
failed process: Process(`/Users/travis/julia/bin/julia -Ccore2 -J/Users/travis/julia/lib/julia/sys.dylib --compile=yes --depwarn=yes --check-bounds=yes --code-coverage=user --inline=no --color=no --compilecache=yes /Users/travis/.julia/v0.5/SCIP/test/runtests.jl`, ProcessSignaled(11)) [0]
================================================================================
```

Not sure what to do with this error. 


In my local machine, I tested each test instance:

```
include("more_tests.jl") x
include("mixintprog.jl") o
include(joinpath(Pkg.dir("JuMP"),"test","model.jl")) x
include(joinpath(Pkg.dir("JuMP"),"test","probmod.jl")) o
include(joinpath(Pkg.dir("JuMP"),"test","qcqpmodel.jl")) x
include(joinpath(Pkg.dir("JuMP"),"test","callback.jl"))  x
include(joinpath(Pkg.dir("JuMP"),"test","nonlinear.jl")) x
```

`x` means `signal (11): Segmentation fault: 11`.
`o` means Test Passed.

