### PR TITLE
Allow prefix for all output from SCIP

### DIFF
--- a/deps/csip_version.jl
+++ b/deps/csip_version.jl
@@ -1,5 +1,5 @@
 # required version and utilities in a single location
-CSIP_VERSION = "0.4.4"
+CSIP_VERSION = "0.4.5"
 
 function vn2int(vn::VersionNumber)
     100*vn.major + 10*vn.minor + vn.patch

--- a/deps/csip_version.jl
+++ b/deps/csip_version.jl
@@ -1,5 +1,5 @@
 # required version and utilities in a single location
-CSIP_VERSION = "0.4.3"
+CSIP_VERSION = "0.4.4"
 
 function vn2int(vn::VersionNumber)
     100*vn.major + 10*vn.minor + vn.patch

--- a/src/SCIP.jl
+++ b/src/SCIP.jl
@@ -28,7 +28,7 @@ function __init__()
     csip_installed = CSIPversion()
     if csip_installed != csip_required
         depsdir = realpath(joinpath(dirname(@__FILE__),"..","deps"))
-        error("Current CSIP version installed is $(csip_installed), but we require $(csip_required). On Linux, delete the contents of the `$depsdir` directory except for `build.jl` and `csip_version.jl`, then rerun Pkg.build(\"SCIP\").")
+        error("Installed CSIP version is $(csip_installed), but we require $(csip_required). Run Pkg.build(\"SCIP\") to update.")
     end
 end
 

--- a/src/csip_wrapper.jl
+++ b/src/csip_wrapper.jl
@@ -256,3 +256,8 @@ function _getInternalSCIP(model::SCIPMathProgModel)
     ccall((:CSIPgetInternalSCIP, libcsip), Ptr{Void}, (Ptr{Void}, ),
           model.inner.ptr_model)
 end
+
+function _setMessagePrefix(model::SCIPMathProgModel, prefix::Ptr{UInt8})
+    ccall((:CSIPsetMessagePrefix, libcsip), Cint, (Ptr{Void}, Cstring),
+          model.inner.ptr_model, prefix)
+end

--- a/src/params.jl
+++ b/src/params.jl
@@ -23,3 +23,10 @@ end
 setparameter!(m::SCIPMathProgModel, name::Compat.String, value::Float64) = (@assert isascii(name); _setRealParam(m, pointer(name), Cdouble(value)))
 setparameter!(m::SCIPMathProgModel, name::Compat.String, value::Char) = (@assert isascii(name); _setCharParam(m, pointer(name), Cchar(value)))
 setparameter!(m::SCIPMathProgModel, name::Compat.String, value::Compat.String) = (@assert isascii(name) && isascii(value); _setStringParam(m, pointer(name), pointer(value)))
+
+# Set a prefix string to be printed with all messages from the solver
+function setprefix!(m::SCIPMathProgModel, prefix)
+    prefix ≠ nothing || return
+    @assert isascii(prefix)
+    _setMessagePrefix(m, pointer(prefix))
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -48,19 +48,24 @@ SCIPMathProgModel = Union{SCIPLinearQuadraticModel, SCIPNonlinearModel}
 
 mutable struct SCIPSolver <: AbstractMathProgSolver
     options
+    prefix
 end
 
-SCIPSolver(kwargs...) = SCIPSolver(kwargs)
+function SCIPSolver(kwargs...; prefix=nothing)
+    SCIPSolver(kwargs, prefix)
+end
 
 function LinearQuadraticModel(s::SCIPSolver)
     m = SCIPLinearQuadraticModel(SCIPModel(s.options))
     setparams!(m)
+    setprefix!(m, s.prefix)
     m
 end
 
 function NonlinearModel(s::SCIPSolver)
     m = SCIPNonlinearModel(SCIPModel(s.options))
     setparams!(m)
+    setprefix!(m, s.prefix)
     m
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -49,10 +49,10 @@ SCIPMathProgModel = Union{SCIPLinearQuadraticModel, SCIPNonlinearModel}
 mutable struct SCIPSolver <: AbstractMathProgSolver
     options
     prefix
-end
 
-function SCIPSolver(kwargs...; prefix=nothing)
-    SCIPSolver(kwargs, prefix)
+    function SCIPSolver(kwargs...; prefix=nothing)
+        new(kwargs, prefix)
+    end
 end
 
 function LinearQuadraticModel(s::SCIPSolver)


### PR DESCRIPTION
This will make it easier to distinguish between different solvers running (to solve subproblems in callbacks, say).