### PR TITLE
Deal with implicit and duplicate constraints for variable bounds

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -204,8 +204,8 @@ function MOI.set(o::SCIP.Optimizer, ::MOI.ConstraintSet, ci::CI{SVF,S}, set::S) 
     allow_modification(o)
     v = var(o, VI(ci.value)) # cons index is actually var index
     lb, ub = bounds(set)
-    lb == nothing || @SC SCIPchgVarLb(scip(o), v, lb)
-    ub == nothing || @SC SCIPchgVarUb(scip(o), v, ub)
+    @SC SCIPchgVarLb(scip(o), v, lb == nothing ? -SCIPinfinity(scip(o)) : lb)
+    @SC SCIPchgVarUb(scip(o), v, ub == nothing ?  SCIPinfinity(scip(o)) : ub)
     return nothing
 end
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -270,7 +270,7 @@ function MOI.get(o::Optimizer, ::MOI.ConstraintFunction, ci::CI{SVF, S}) where S
 end
 
 function MOI.get(o::Optimizer, ::MOI.ConstraintSet, ci::CI{SVF, S}) where S <: BOUNDS
-    v = var(o.mscip, ci.value)
+    v = var(o, VI(ci.value))
     lb, ub = SCIPvarGetLbOriginal(v), SCIPvarGetUbOriginal(v)
     return from_bounds(S, lb, ub)
 end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -164,7 +164,7 @@ function MOI.add_constraint(o::Optimizer, func::SVF, set::S) where {S <: VAR_TYP
         # Need to adjust bounds for SCIP, which fails with an error otherwise.
         # Check for conflicts with existing bounds first:
         lb, ub = SCIPvarGetLbOriginal(v), SCIPvarGetUbOriginal(v)
-        if lb == 0.0 && up == 1.0
+        if lb == 0.0 && ub == 1.0
             # nothing to be done
         elseif lb == -SCIPinfinity(scip(o)) && ub == SCIPinfinity(scip(o))
             @warn "Implicitly setting bounds [0,1] for binary variable at $(vi.value)!" maxlog=1

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -184,17 +184,18 @@ function MOI.add_constraint(o::Optimizer, func::SVF, set::S) where S <: BOUNDS
     s = scip(o)
     vi = func.variable
     v = var(o, vi)
+    newlb, newub = bounds(set)
 
     # Check for existing bounds first.
-    if (SCIPvarGetLbOriginal(v) != -SCIPinfinity(s)
-        || SCIPvarGetUbOriginal(v) != SCIPinfinity(s))
+    oldlb, oldub = SCIPvarGetLbOriginal(v), SCIPvarGetUbOriginal(v)
+    inf = SCIPinfinity(s)
+    if (oldlb != -inf || oldub != inf)
         throw(MOI.AddConstraintNotAllowed{SVF, S}(
             "Already have bounds for variable at $(vi.value)!"))
     end
 
-    lb, ub = bounds(set)
-    lb == nothing || @SC SCIPchgVarLb(scip(o), v, lb)
-    ub == nothing || @SC SCIPchgVarUb(scip(o), v, ub)
+    newlb == nothing || @SC SCIPchgVarLb(scip(o), v, lb)
+    newub == nothing || @SC SCIPchgVarUb(scip(o), v, ub)
     # use var index for cons index of this type
     i = func.variable.value
     return register!(o, CI{SVF, S}(i))

--- a/test/MOI_additional.jl
+++ b/test/MOI_additional.jl
@@ -1,0 +1,27 @@
+using MathOptInterface
+const MOI = MathOptInterface
+
+@testset "Binary variables and bounds" begin
+    optimizer = SCIP.Optimizer()
+
+    # Should work: binary variable no explicit bounds
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+    @test !MOI.is_empty(optimizer)
+
+    # Should work: binary variable with [0, 1] bounds
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.Interval(0.0, 1.0))
+    t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+    @test !MOI.is_empty(optimizer)
+
+    # Should work: binary variable with [0, 1] bounds (order should not matter)
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+    b = MOI.add_constraint(optimizer, x, MOI.Interval(0.0, 1.0))
+    @test !MOI.is_empty(optimizer)
+
+end

--- a/test/MOI_additional.jl
+++ b/test/MOI_additional.jl
@@ -1,6 +1,14 @@
 using MathOptInterface
 const MOI = MathOptInterface
 
+const VI = MOI.VariableIndex
+const CI = MOI.ConstraintIndex
+const SVF = MOI.SingleVariable
+
+function var_bounds(o::SCIP.Optimizer, vi::VI)
+    return MOI.get(o, MOI.ConstraintSet(), CI{SVF,MOI.Interval{Float64}}(vi.value))
+end
+
 @testset "Binary variables and explicit bounds" begin
     optimizer = SCIP.Optimizer()
 
@@ -8,49 +16,49 @@ const MOI = MathOptInterface
     MOI.empty!(optimizer)
     x = MOI.add_variable(optimizer)
     t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
-    @test !MOI.is_empty(optimizer)
+    @test var_bounds(optimizer, x) == MOI.Interval(0.0, 1.0)
 
     # Should work: binary variable with [0, 1] bounds
     MOI.empty!(optimizer)
     x = MOI.add_variable(optimizer)
     b = MOI.add_constraint(optimizer, x, MOI.Interval(0.0, 1.0))
     t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
-    @test !MOI.is_empty(optimizer)
+    @test var_bounds(optimizer, x) == MOI.Interval(0.0, 1.0)
 
     # Should work: binary variable with [0, 1] bounds (order should not matter)
     MOI.empty!(optimizer)
     x = MOI.add_variable(optimizer)
     t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
     b = MOI.add_constraint(optimizer, x, MOI.Interval(0.0, 1.0))
-    @test !MOI.is_empty(optimizer)
+    @test var_bounds(optimizer, x) == MOI.Interval(0.0, 1.0)
 
     # Should work: binary variable fixed to 0.
     MOI.empty!(optimizer)
     x = MOI.add_variable(optimizer)
     t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
     b = MOI.add_constraint(optimizer, x, MOI.EqualTo(0.0))
-    @test !MOI.is_empty(optimizer)
+    @test var_bounds(optimizer, x) == MOI.Interval(0.0, 0.0)
 
     # Should work: binary variable fixed to 0 (different order).
     MOI.empty!(optimizer)
     x = MOI.add_variable(optimizer)
     b = MOI.add_constraint(optimizer, x, MOI.EqualTo(0.0))
     t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
-    @test !MOI.is_empty(optimizer)
+    @test var_bounds(optimizer, x) == MOI.Interval(0.0, 0.0)
 
     # Should work: binary variable fixed to 1.
     MOI.empty!(optimizer)
     x = MOI.add_variable(optimizer)
     t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
     b = MOI.add_constraint(optimizer, x, MOI.EqualTo(1.0))
-    @test !MOI.is_empty(optimizer)
+    @test var_bounds(optimizer, x) == MOI.Interval(1.0, 1.0)
 
     # Should work: binary variable fixed to 1 (different order).
     MOI.empty!(optimizer)
     x = MOI.add_variable(optimizer)
     b = MOI.add_constraint(optimizer, x, MOI.EqualTo(1.0))
     t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
-    @test !MOI.is_empty(optimizer)
+    @test var_bounds(optimizer, x) == MOI.Interval(1.0, 1.0)
 
     # Is an error: binary variable with too wide bounds.
     MOI.empty!(optimizer)

--- a/test/MOI_additional.jl
+++ b/test/MOI_additional.jl
@@ -9,6 +9,12 @@ function var_bounds(o::SCIP.Optimizer, vi::VI)
     return MOI.get(o, MOI.ConstraintSet(), CI{SVF,MOI.Interval{Float64}}(vi.value))
 end
 
+function chg_bounds(o::SCIP.Optimizer, vi::VI, set::S) where S
+    ci = CI{SVF,S}(vi.value)
+    MOI.set(o, MOI.ConstraintSet(), ci, set)
+    return nothing
+end
+
 @testset "Binary variables and explicit bounds" begin
     optimizer = SCIP.Optimizer()
 
@@ -131,4 +137,49 @@ end
     x = MOI.add_variable(optimizer)
     lb = MOI.add_constraint(optimizer, x, MOI.GreaterThan(2.0))
     @test_throws ErrorException ub = MOI.add_constraint(optimizer, x, MOI.LessThan(3.0))
+end
+
+@testset "Changing bounds for variable." begin
+    optimizer = SCIP.Optimizer()
+    inf = SCIP.SCIPinfinity(SCIP.scip(optimizer))
+
+    # change interval bounds
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.Interval(2.0, 3.0))
+    @test var_bounds(optimizer, x) == MOI.Interval(2.0, 3.0)
+    chg_bounds(optimizer, x, MOI.Interval(4.0, 5.0))
+    @test var_bounds(optimizer, x) == MOI.Interval(4.0, 5.0)
+
+    # change lower bound
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.GreaterThan(2.0))
+    @test var_bounds(optimizer, x) == MOI.Interval(2.0, inf)
+    chg_bounds(optimizer, x, MOI.GreaterThan(4.0))
+    @test var_bounds(optimizer, x) == MOI.Interval(4.0, inf)
+
+    # change upper bound
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.LessThan(3.0))
+    @test var_bounds(optimizer, x) == MOI.Interval(-inf, 3.0)
+    chg_bounds(optimizer, x, MOI.LessThan(5.0))
+    @test var_bounds(optimizer, x) == MOI.Interval(-inf, 5.0)
+
+    # change fixed value
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.EqualTo(2.5))
+    @test var_bounds(optimizer, x) == MOI.Interval(2.5, 2.5)
+    chg_bounds(optimizer, x, MOI.EqualTo(4.5))
+    @test var_bounds(optimizer, x) == MOI.Interval(4.5, 4.5)
+
+    # change mixed
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.GreaterThan(2.0))
+    @test var_bounds(optimizer, x) == MOI.Interval(2.0, inf)
+    chg_bounds(optimizer, x, MOI.LessThan(4.0))
+    @test var_bounds(optimizer, x) == MOI.Interval(-inf, 4.0)
 end

--- a/test/MOI_additional.jl
+++ b/test/MOI_additional.jl
@@ -1,10 +1,10 @@
 using MathOptInterface
 const MOI = MathOptInterface
 
-@testset "Binary variables and bounds" begin
+@testset "Binary variables and explicit bounds" begin
     optimizer = SCIP.Optimizer()
 
-    # Should work: binary variable no explicit bounds
+    # Should work: binary variable without explicit bounds
     MOI.empty!(optimizer)
     x = MOI.add_variable(optimizer)
     t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
@@ -24,4 +24,55 @@ const MOI = MathOptInterface
     b = MOI.add_constraint(optimizer, x, MOI.Interval(0.0, 1.0))
     @test !MOI.is_empty(optimizer)
 
+    # Should work: binary variable fixed to 0.
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+    b = MOI.add_constraint(optimizer, x, MOI.EqualTo(0.0))
+    @test !MOI.is_empty(optimizer)
+
+    # Should work: binary variable fixed to 0 (different order).
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.EqualTo(0.0))
+    t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+    @test !MOI.is_empty(optimizer)
+
+    # Should work: binary variable fixed to 1.
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+    b = MOI.add_constraint(optimizer, x, MOI.EqualTo(1.0))
+    @test !MOI.is_empty(optimizer)
+
+    # Should work: binary variable fixed to 1 (different order).
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.EqualTo(1.0))
+    t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+    @test !MOI.is_empty(optimizer)
+
+    # Is an error: binary variable with too wide bounds.
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.Interval(-1.0, 2.0))
+    @test_throws ErrorException t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+
+    # Is an error: binary variable with too wide bounds (different order).
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+    @test_throws ErrorException b = MOI.add_constraint(optimizer, x, MOI.Interval(-1.0, 2.0))
+
+    # Is an error: binary variable with conflicting bounds (infeasible).
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    b = MOI.add_constraint(optimizer, x, MOI.Interval(2.0, 3.0))
+    @test_throws ErrorException t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+
+    # Is an error: binary variable with conflicting bounds (infeasible, different order).
+    MOI.empty!(optimizer)
+    x = MOI.add_variable(optimizer)
+    t = MOI.add_constraint(optimizer, x, MOI.ZeroOne())
+    @test_throws ErrorException b = MOI.add_constraint(optimizer, x, MOI.Interval(2.0, 3.0))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,3 +12,7 @@ end
 @testset "MathOptInterface tests" begin
     include("MOI_wrapper.jl")
 end
+
+@testset "MathOptInterface additional tests" begin
+    include("MOI_additional.jl")
+end


### PR DESCRIPTION
fixes #79 

Still needs additional tests. Maybe prints too many warnings now. Probably is too conservative (does not consider variable type when throwing error about existing bounds).

In particular, will still fail for these cases now:
- fixing a binary variable
- having two separate constraints, one for the lower bound, one for the upper bound