### PR TITLE
Run more MOI tests, using the ScalarizeBridge

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -145,6 +145,10 @@ function MOI.get(o::Optimizer, ::MOI.NumberOfConstraints{F,S}) where {F,S}
     return haskey(o.constypes, (F, S)) ? length(o.constypes[F, S]) : 0
 end
 
+function MOI.get(o::Optimizer, ::MOI.ListOfConstraints)
+    return collect(keys(o.constypes))
+end
+
 function MOI.optimize!(o::Optimizer)
     @SC SCIPsolve(o)
     return nothing

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -4,8 +4,9 @@ const MOIB = MOI.Bridges
 const MOIT = MOI.Test
 
 const OPTIMIZER = SCIP.Optimizer(display_verblevel=0)
-const CONFIG = MOIT.TestConfig(duals=false, infeas_certificates=false)
 const SCALARIZED = MOIB.Scalarize{Float64}(SCIP.Optimizer(display_verblevel=0))
+const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false,
+                               infeas_certificates=false)
 
 @testset "MOI Continuous Linear" begin
     excluded = [
@@ -33,9 +34,6 @@ end
     MOIT.contlineartest(SCALARIZED, CONFIG, excluded)
 end
 
-@testset "MOI Integer Linear" begin
-    MOIT.intlineartest(OPTIMIZER, CONFIG)
-end
 
 @testset "MOI Quadratic Constraint" begin
     excluded = [
@@ -43,3 +41,12 @@ end
     ]
     MOIT.qcptest(OPTIMIZER, CONFIG, excluded)
 end
+
+@testset "MOI Quadratic Constraint - ScalarizeBridge" begin
+    MOIT.qcptest(SCALARIZED, CONFIG)
+end
+
+@testset "MOI Integer Linear" begin
+    MOIT.intlineartest(OPTIMIZER, CONFIG)
+end
+

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1,9 +1,11 @@
 using MathOptInterface
 const MOI = MathOptInterface
+const MOIB = MOI.Bridges
 const MOIT = MOI.Test
 
-const optimizer = SCIP.Optimizer(display_verblevel=0)
-const config = MOIT.TestConfig(duals=false, infeas_certificates=false)
+const OPTIMIZER = SCIP.Optimizer(display_verblevel=0)
+const CONFIG = MOIT.TestConfig(duals=false, infeas_certificates=false)
+const SCALARIZED = MOIB.Scalarize{Float64}(SCIP.Optimizer(display_verblevel=0))
 
 @testset "MOI Continuous Linear" begin
     excluded = [
@@ -16,16 +18,28 @@ const config = MOIT.TestConfig(duals=false, infeas_certificates=false)
         "linear15", # needs MOI.VectorAffineFunction
         "partial_start", # TODO: supportVariablePrimalStart
     ]
-    MOIT.contlineartest(optimizer, config, excluded)
+    MOIT.contlineartest(OPTIMIZER, CONFIG, excluded)
+end
+
+@testset "MOI Continuous Linear - ScalarizeBridge" begin
+    excluded = [
+        "linear1",  # needs MOI.delete (of variables in constraints)
+        "linear5",  # needs MOI.delete (of variables in constraints)
+        "linear11", # broken in SCIP (#2556)
+        "linear13", # TODO: support MOI.FEASIBILITY_SENSE
+        "linear14", # needs MOI.delete (of variables in constraints)
+        "partial_start", # TODO: supportVariablePrimalStart
+    ]
+    MOIT.contlineartest(SCALARIZED, CONFIG, excluded)
 end
 
 @testset "MOI Integer Linear" begin
-    MOIT.intlineartest(optimizer, config)
+    MOIT.intlineartest(OPTIMIZER, CONFIG)
 end
 
 @testset "MOI Quadratic Constraint" begin
     excluded = [
         "qcp1", # needs VectorAffineFunction
     ]
-    MOIT.qcptest(optimizer, config, excluded)
+    MOIT.qcptest(OPTIMIZER, CONFIG, excluded)
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -34,6 +34,11 @@ end
     MOIT.contlineartest(SCALARIZED, CONFIG, excluded)
 end
 
+# @testset "MOI Continuous Conic - ScalarizeBridge" begin
+#     excluded = String[
+#     ]
+#     MOIT.contconictest(SCALARIZED, CONFIG, excluded)
+# end
 
 @testset "MOI Quadratic Constraint" begin
     excluded = [
@@ -49,4 +54,10 @@ end
 @testset "MOI Integer Linear" begin
     MOIT.intlineartest(OPTIMIZER, CONFIG)
 end
+
+# @testset "MOI Integer Conic - ScalarizeBridge" begin
+#     excluded = String[
+#     ]
+#     MOIT.intconictest(SCALARIZED, CONFIG, excluded)
+# end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -34,11 +34,14 @@ end
     MOIT.contlineartest(SCALARIZED, CONFIG, excluded)
 end
 
-# @testset "MOI Continuous Conic - ScalarizeBridge" begin
-#     excluded = String[
-#     ]
-#     MOIT.contconictest(SCALARIZED, CONFIG, excluded)
-# end
+@testset "MOI Continuous Conic - ScalarizeBridge" begin
+    MOIT.lintest(SCALARIZED, CONFIG)
+
+    # needs VectorAffineFunction
+    # MOIT.soctest(SCALARIZED, CONFIG)
+
+    # other cones not supported
+end
 
 @testset "MOI Quadratic Constraint" begin
     excluded = [
@@ -55,9 +58,7 @@ end
     MOIT.intlineartest(OPTIMIZER, CONFIG)
 end
 
-# @testset "MOI Integer Conic - ScalarizeBridge" begin
-#     excluded = String[
-#     ]
-#     MOIT.intconictest(SCALARIZED, CONFIG, excluded)
-# end
-
+@testset "MOI Integer Conic - ScalarizeBridge" begin
+    # needs VectorAffineFunction
+    # MOIT.intconictest(SCALARIZED, CONFIG)
+end


### PR DESCRIPTION
This adds mostly LP tests. Would still need to support `VectorAffineFunction` for the other conic tests :-(