### PR TITLE
Handle parameter types properly.

### DIFF
--- a/src/managed_scip.jl
+++ b/src/managed_scip.jl
@@ -49,9 +49,28 @@ function free_scip(mscip::ManagedSCIP)
     @assert mscip.scip[] == C_NULL
 end
 
-"Set generic parameter."
-function set_parameter(mscip::ManagedSCIP, name::String, value)
-    @SC SCIPsetParam(mscip, name, Ptr{Cvoid}(value))
+"Set a parameter."
+function set_parameter(mscip::ManagedSCIP, name::AbstractString, value)
+    param = SCIPgetParam(mscip, name)
+    if param == C_NULL
+        error("Unrecognized parameter: $name")
+    end
+    paramtype = SCIPparamGetType(param)
+    if paramtype === SCIP_PARAMTYPE_BOOL
+        @SC SCIPsetBoolParam(mscip, name, value)
+    elseif paramtype === SCIP_PARAMTYPE_INT
+        @SC SCIPsetIntParam(mscip, name, value)
+    elseif paramtype === SCIP_PARAMTYPE_LONGINT
+        @SC SCIPsetLongintParam(mscip, name, value)
+    elseif paramtype === SCIP_PARAMTYPE_REAL
+        @SC SCIPsetRealParam(mscip, name, value)
+    elseif paramtype === SCIP_PARAMTYPE_CHAR
+        @SC SCIPsetCharParam(mscip, name, value)
+    elseif paramtype === SCIP_PARAMTYPE_STRING
+        @SC SCIPsetStringParam(mscip, name, value)
+    else
+        error("Unexpected parameter type: $paramtype")
+    end
     return nothing
 end
 

--- a/test/MOI_additional.jl
+++ b/test/MOI_additional.jl
@@ -388,3 +388,27 @@ end
     MOI.set(optimizer, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     @test_throws ErrorException MOI.get(optimizer, MOI.ObjectiveFunction{MOI.SingleVariable}())
 end
+
+@testset "set_parameter" begin
+    # TODO: verify that the parameter was actually set (implement a get_parameter function)
+    # bool
+    optimizer = SCIP.Optimizer(branching_preferbinary=true)
+
+    # int
+    optimizer = SCIP.Optimizer(conflict_minmaxvars=1)
+
+    # long int
+    optimizer = SCIP.Optimizer(heuristics_alns_maxnodes=2)
+
+    # real
+    optimizer = SCIP.Optimizer(branching_scorefac=0.15)
+
+    # char
+    optimizer = SCIP.Optimizer(branching_scorefunc='s')
+
+    # string
+    optimizer = SCIP.Optimizer(heuristics_alns_rewardfilename="abc.txt")
+
+    # invalid
+    @test_throws ErrorException SCIP.Optimizer(some_invalid_param_name=true)
+end


### PR DESCRIPTION
This aims to restore the same functionality that was introduced in https://github.com/SCIP-Interfaces/SCIP.jl/pull/16, but I chose to have the type of parameter be fully guided by what SCIP thinks it should be (using `SCIPparamGetType`), rather than using dispatch on the Julia side. `cconvert` should take care of the rest.

Fixes #15.