### PR TITLE
Add OSX support (+ Travis testing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ matrix:
   allow_failures:
     - julia: nightly
 addons:
-  homebrew:
-    packages:
-      - gcc@6
   apt:
     packages:
     - libblas3
@@ -33,12 +30,13 @@ addons:
     - zlib1g
 before_install:
   - export VERSION=6.0.1
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export SCIP_BINARY=SCIPOptSuite-$VERSION-Linux.deb; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export SCIP_BINARY=SCIPOptSuite-$VERSION-Darwin-no-Ipopt.sh; fi
-  - wget http://scip.zib.de/download/release/$SCIP_BINARY
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget http://scip.zib.de/download/release/SCIPOptSuite-$VERSION-Linux.deb; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo dpkg -i SCIPOptSuite-$VERSION-Linux.deb; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then chmod +x $SCIP_BINARY && mkdir scip && ./$SCIP_BINARY --skip-license --prefix=$(pwd)/scip; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export SCIPOPTDIR=$(pwd)/scip; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget http://scip.zib.de/download/release/scipoptsuite-$VERSION.tgz; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then tar -xf scipoptsuite-$VERSION.tgz && cd scipoptsuite-$VERSION; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mkdir build && cd build && cmake -D CMAKE_BUILD_TYPE=Release -D ZIMPL=OFF -D GCG=OFF -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=../install ..; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then make -j 4 && make install; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cd .. && export SCIPOPTDIR=$(pwd)/install && cd ..; fi
 # Use default build script.
 # script:
 #   - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("SCIP"); Pkg.test("SCIP"; coverage=true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ## Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-os: linux
+os:
+  - linux
+  - osx
 dist: xenial
 sudo: true
 julia:
@@ -14,13 +16,32 @@ git:
 matrix:
   allow_failures:
     - julia: nightly
+addons:
+  homebrew:
+    packages:
+      - gcc@6
+  apt:
+    packages:
+    - libblas3
+    - libc6
+    - libgcc1
+    - libgfortran3
+    - libgmp10
+    - libgsl2
+    - liblapack3
+    - libstdc++6
+    - zlib1g
 before_install:
-  - sudo apt-get install libblas3 libc6 libgcc1 libgfortran3 libgmp10 libgsl2 liblapack3 libstdc++6 zlib1g
   - export VERSION=6.0.1
-  - wget http://scip.zib.de/download/release/SCIPOptSuite-$VERSION-Linux.deb
-  - sudo dpkg -i SCIPOptSuite-$VERSION-Linux.deb
-script:
-  - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("SCIP"); Pkg.test("SCIP"; coverage=true)'
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export SCIP_BINARY=SCIPOptSuite-$VERSION-Linux.deb; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export SCIP_BINARY=SCIPOptSuite-$VERSION-Darwin-no-Ipopt.sh; fi
+  - wget http://scip.zib.de/download/release/$SCIP_BINARY
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo dpkg -i SCIPOptSuite-$VERSION-Linux.deb; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then chmod +x $SCIP_BINARY && mkdir scip && ./$SCIP_BINARY --skip-license --prefix=$(pwd)/scip; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export SCIPOPTDIR=$(pwd)/scip; fi
+# Use default build script.
+# script:
+#   - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("SCIP"); Pkg.test("SCIP"; coverage=true)'
 jobs:
   include:
     - stage: "MINLPTests"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,14 +11,19 @@ function write_depsfile(path)
     close(f)
 end
 
-libname = "libscip.so"
+libname = if Sys.islinux()
+    "libscip.so"
+elseif Sys.isapple()
+    "libscip.dylib"
+else
+    error("SCIP is currently not supported on \"$(Sys.KERNEL)\"")
+end
+
 paths_to_try = []
 
 # prefer environment variable
 if haskey(ENV, "SCIPOPTDIR")
-    if Sys.islinux()
-        push!(paths_to_try, joinpath(ENV["SCIPOPTDIR"], "lib", libname))
-    end
+    push!(paths_to_try, joinpath(ENV["SCIPOPTDIR"], "lib", libname))
 end
 
 # but also try library path

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -40,7 +40,10 @@ for l in paths_to_try
 end
 
 if !found && !haskey(ENV, "SCIP_JL_SKIP_LIB_CHECK")
-    error("Unable to locate SCIP installation. " *
-          "Note that this must be downloaded separately from scip.zib.de. " *
-          "Please set the environment variable SCIPOPTDIR to SCIP's installation path.")
+    error("""
+Unable to locate SCIP installation.
+Tried:\n\t$(join(paths_to_try, "\n\t"))
+Note that this must be downloaded separately from scip.zib.de.
+Please set the environment variable SCIPOPTDIR to SCIP's installation path.
+""")
 end


### PR DESCRIPTION
Took about 5 minutes for the actual change and several hours to get Travis working. I initially wanted to use the precompiled binaries, but I ran into an illegal instruction on OSX, https://travis-ci.org/SCIP-Interfaces/SCIP.jl/jobs/512838942#L227, and decided to compile from source.