### PR TITLE
Improve MOI test usage

### DIFF
--- a/src/MOI_wrapper/variable.jl
+++ b/src/MOI_wrapper/variable.jl
@@ -175,7 +175,7 @@ function MOI.delete(o::Optimizer, ci::CI{SVF,S}) where S <: BOUNDS
     if SCIPvarGetType(v) == SCIP_VARTYPE_BINARY
         reset_bounds(o, v, 0.0, 1.0, ci)
     else
-        inf = SCIPinfinity(s)
+        inf = SCIPinfinity(o)
         reset_bounds(o, v, -inf, inf, ci)
     end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -5,7 +5,7 @@ const MOIT = MOI.Test
 
 const BRIDGED = MOIB.full_bridge_optimizer(SCIP.Optimizer(display_verblevel=0), Float64)
 const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false, infeas_certificates=false)
-const CONFIG3 = MOIT.TestConfig(atol=1e-3, rtol=1e-3, duals=false, infeas_certificates=false)
+const CONFIG3 = MOIT.TestConfig(atol=1e-3, rtol=1e-2, duals=false, infeas_certificates=false)
 
 @testset "MOI Continuous Linear" begin
     excluded = [

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -34,7 +34,11 @@ end
 end
 
 @testset "MOI Quadratic Constraint" begin
+    # needs objective bridge (MOI/#529)
+    # MOIT.qptest(BRIDGED, CONFIG)
+
     MOIT.qcptest(BRIDGED, CONFIG)
+    MOIT.socptest(BRIDGED, CONFIG)
 end
 
 @testset "MOI Integer Linear" begin

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -3,24 +3,9 @@ const MOI = MathOptInterface
 const MOIB = MOI.Bridges
 const MOIT = MOI.Test
 
-const OPTIMIZER = SCIP.Optimizer(display_verblevel=0)
 const SCALARIZED = MOIB.Scalarize{Float64}(SCIP.Optimizer(display_verblevel=0))
 const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false,
                                infeas_certificates=false)
-
-@testset "MOI Continuous Linear" begin
-    excluded = [
-        "linear1",  # needs MOI.delete (of variables in constraints)
-        "linear5",  # needs MOI.delete (of variables in constraints)
-        "linear7",  # needs MOI.VectorAffineFunction
-        "linear11", # broken in SCIP (#2556)
-        "linear13", # TODO: support MOI.FEASIBILITY_SENSE
-        "linear14", # needs MOI.delete (of variables in constraints)
-        "linear15", # needs MOI.VectorAffineFunction
-        "partial_start", # TODO: supportVariablePrimalStart
-    ]
-    MOIT.contlineartest(OPTIMIZER, CONFIG, excluded)
-end
 
 @testset "MOI Continuous Linear - ScalarizeBridge" begin
     excluded = [
@@ -43,19 +28,8 @@ end
     # other cones not supported
 end
 
-@testset "MOI Quadratic Constraint" begin
-    excluded = [
-        "qcp1", # needs VectorAffineFunction
-    ]
-    MOIT.qcptest(OPTIMIZER, CONFIG, excluded)
-end
-
 @testset "MOI Quadratic Constraint - ScalarizeBridge" begin
     MOIT.qcptest(SCALARIZED, CONFIG)
-end
-
-@testset "MOI Integer Linear" begin
-    MOIT.intlineartest(OPTIMIZER, CONFIG)
 end
 
 @testset "MOI Integer Conic - ScalarizeBridge" begin

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -23,8 +23,14 @@ end
 
     # SOC tests fail because of lower bound requirement of RHS var.
     # MOIT.soctest(BRIDGED, CONFIG)
+    # MOIT.rsoctest(BRIDGED, CONFIG)
 
     # other cones not supported
+    # MOIT.geomeantest(BRIDGED, CONFIG)
+    # MOIT.exptest(BRIDGED, CONFIG)
+    # MOIT.sdptest(BRIDGED, CONFIG)
+    # MOIT.logdettest(BRIDGED, CONFIG)
+    # MOIT.rootdettest(BRIDGED, CONFIG)
 end
 
 @testset "MOI Quadratic Constraint" begin

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -3,11 +3,10 @@ const MOI = MathOptInterface
 const MOIB = MOI.Bridges
 const MOIT = MOI.Test
 
-const SCALARIZED = MOIB.Scalarize{Float64}(SCIP.Optimizer(display_verblevel=0))
-const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false,
-                               infeas_certificates=false)
+const BRIDGED = MOIB.full_bridge_optimizer(SCIP.Optimizer(display_verblevel=0), Float64)
+const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false, infeas_certificates=false)
 
-@testset "MOI Continuous Linear - ScalarizeBridge" begin
+@testset "MOI Continuous Linear" begin
     excluded = [
         "linear1",  # needs MOI.delete (of variables in constraints)
         "linear5",  # needs MOI.delete (of variables in constraints)
@@ -16,27 +15,27 @@ const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false,
         "linear14", # needs MOI.delete (of variables in constraints)
         "partial_start", # TODO: supportVariablePrimalStart
     ]
-    MOIT.contlineartest(SCALARIZED, CONFIG, excluded)
+    MOIT.contlineartest(BRIDGED, CONFIG, excluded)
 end
 
-@testset "MOI Continuous Conic - ScalarizeBridge" begin
-    MOIT.lintest(SCALARIZED, CONFIG)
+@testset "MOI Continuous Conic" begin
+    MOIT.lintest(BRIDGED, CONFIG)
 
     # needs VectorAffineFunction
-    # MOIT.soctest(SCALARIZED, CONFIG)
+    # MOIT.soctest(BRIDGED, CONFIG)
 
     # other cones not supported
 end
 
-@testset "MOI Quadratic Constraint - ScalarizeBridge" begin
-    MOIT.qcptest(SCALARIZED, CONFIG)
+@testset "MOI Quadratic Constraint" begin
+    MOIT.qcptest(BRIDGED, CONFIG)
 end
 
 @testset "MOI Integer Linear" begin
-    MOIT.intlineartest(SCALARIZED, CONFIG)
+    MOIT.intlineartest(BRIDGED, CONFIG)
 end
 
-@testset "MOI Integer Conic - ScalarizeBridge" begin
+@testset "MOI Integer Conic" begin
     # needs VectorAffineFunction
-    # MOIT.intconictest(SCALARIZED, CONFIG)
+    # MOIT.intconictest(BRIDGED, CONFIG)
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -32,6 +32,10 @@ end
     MOIT.qcptest(SCALARIZED, CONFIG)
 end
 
+@testset "MOI Integer Linear" begin
+    MOIT.intlineartest(SCALARIZED, CONFIG)
+end
+
 @testset "MOI Integer Conic - ScalarizeBridge" begin
     # needs VectorAffineFunction
     # MOIT.intconictest(SCALARIZED, CONFIG)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -49,3 +49,13 @@ end
     # SOC tests fail because of lower bound requirement of RHS var.
     # MOIT.intconictest(BRIDGED, CONFIG)
 end
+
+@testset "MOI NLP" begin
+    # None of tests provide expression graphs in the evaluator.
+    # MOIT.nlptest(BRIDGED, CONFIG)
+end
+
+@testset "MOI Unit tests" begin
+    # TODO: most tests need get-variable-by-name etc.
+    # MOIT.unittest(BRIDGED, CONFIG)
+end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -21,7 +21,7 @@ end
 @testset "MOI Continuous Conic" begin
     MOIT.lintest(BRIDGED, CONFIG)
 
-    # needs VectorAffineFunction
+    # SOC tests fail because of lower bound requirement of RHS var.
     # MOIT.soctest(BRIDGED, CONFIG)
 
     # other cones not supported
@@ -36,6 +36,6 @@ end
 end
 
 @testset "MOI Integer Conic" begin
-    # needs VectorAffineFunction
+    # SOC tests fail because of lower bound requirement of RHS var.
     # MOIT.intconictest(BRIDGED, CONFIG)
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -5,6 +5,7 @@ const MOIT = MOI.Test
 
 const BRIDGED = MOIB.full_bridge_optimizer(SCIP.Optimizer(display_verblevel=0), Float64)
 const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false, infeas_certificates=false)
+const CONFIG3 = MOIT.TestConfig(atol=1e-3, rtol=1e-3, duals=false, infeas_certificates=false)
 
 @testset "MOI Continuous Linear" begin
     excluded = [
@@ -38,7 +39,7 @@ end
     # MOIT.qptest(BRIDGED, CONFIG)
 
     MOIT.qcptest(BRIDGED, CONFIG)
-    MOIT.socptest(BRIDGED, CONFIG)
+    MOIT.socptest(BRIDGED, CONFIG3)
 end
 
 @testset "MOI Integer Linear" begin

--- a/test/MOI_wrapper_direct.jl
+++ b/test/MOI_wrapper_direct.jl
@@ -1,0 +1,32 @@
+using MathOptInterface
+const MOI = MathOptInterface
+const MOIT = MOI.Test
+
+const OPTIMIZER = SCIP.Optimizer(display_verblevel=0)
+const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false,
+                               infeas_certificates=false)
+
+@testset "MOI Continuous Linear" begin
+    excluded = [
+        "linear1",  # needs MOI.delete (of variables in constraints)
+        "linear5",  # needs MOI.delete (of variables in constraints)
+        "linear7",  # needs MOI.VectorAffineFunction
+        "linear11", # broken in SCIP (#2556)
+        "linear13", # TODO: support MOI.FEASIBILITY_SENSE
+        "linear14", # needs MOI.delete (of variables in constraints)
+        "linear15", # needs MOI.VectorAffineFunction
+        "partial_start", # TODO: supportVariablePrimalStart
+    ]
+    MOIT.contlineartest(OPTIMIZER, CONFIG, excluded)
+end
+
+@testset "MOI Quadratic Constraint" begin
+    excluded = [
+        "qcp1", # needs VectorAffineFunction
+    ]
+    MOIT.qcptest(OPTIMIZER, CONFIG, excluded)
+end
+
+@testset "MOI Integer Linear" begin
+    MOIT.intlineartest(OPTIMIZER, CONFIG)
+end

--- a/test/MOI_wrapper_direct.jl
+++ b/test/MOI_wrapper_direct.jl
@@ -7,6 +7,7 @@ const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false,
                                infeas_certificates=false)
 
 @testset "MOI Continuous Linear" begin
+    # remember reason for excluded tests:
     excluded = [
         "linear1",  # needs MOI.delete (of variables in constraints)
         "linear5",  # needs MOI.delete (of variables in constraints)
@@ -17,16 +18,42 @@ const CONFIG = MOIT.TestConfig(atol=1e-5, rtol=1e-5, duals=false,
         "linear15", # needs MOI.VectorAffineFunction
         "partial_start", # TODO: supportVariablePrimalStart
     ]
-    MOIT.contlineartest(OPTIMIZER, CONFIG, excluded)
+    # MOIT.contlineartest(OPTIMIZER, CONFIG, excluded)
+
+    # call individual tests
+    MOIT.linear2test(OPTIMIZER, CONFIG)
+    MOIT.linear3test(OPTIMIZER, CONFIG)
+    MOIT.linear4test(OPTIMIZER, CONFIG)
+    MOIT.linear6test(OPTIMIZER, CONFIG)
+    MOIT.linear8atest(OPTIMIZER, CONFIG)
+    MOIT.linear8btest(OPTIMIZER, CONFIG)
+    MOIT.linear8ctest(OPTIMIZER, CONFIG)
+    MOIT.linear9test(OPTIMIZER, CONFIG)
+    MOIT.linear10test(OPTIMIZER, CONFIG)
+    MOIT.linear10btest(OPTIMIZER, CONFIG)
+    MOIT.linear12test(OPTIMIZER, CONFIG)
 end
 
 @testset "MOI Quadratic Constraint" begin
+    # remember reason for excluded tests:
     excluded = [
         "qcp1", # needs VectorAffineFunction
     ]
-    MOIT.qcptest(OPTIMIZER, CONFIG, excluded)
+    # MOIT.qcptest(OPTIMIZER, CONFIG, excluded)
+
+    # call individual tests
+    MOIT.qcp2test(OPTIMIZER, CONFIG)
+    MOIT.qcp3test(OPTIMIZER, CONFIG)
+    # MOIT.qcp4test(OPTIMIZER, CONFIG)  # not yet merged
+    # MOIT.qcp5test(OPTIMIZER, CONFIG)  # not yet merged
 end
 
 @testset "MOI Integer Linear" begin
-    MOIT.intlineartest(OPTIMIZER, CONFIG)
+    # MOIT.intlineartest(OPTIMIZER, CONFIG)
+
+    # call individual tests
+    MOIT.knapsacktest(OPTIMIZER, CONFIG)
+    MOIT.int1test(OPTIMIZER, CONFIG)
+    MOIT.int2test(OPTIMIZER, CONFIG)
+    MOIT.int3test(OPTIMIZER, CONFIG)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,12 @@ end
     include("managed_scip.jl")
 end
 
-@testset "MathOptInterface tests" begin
+@testset "MathOptInterface tests (bridged)" begin
     include("MOI_wrapper.jl")
+end
+
+@testset "MathOptInterface tests (direct)" begin
+    include("MOI_wrapper_direct.jl")
 end
 
 @testset "MathOptInterface additional tests" begin


### PR DESCRIPTION
- following discussion in https://github.com/JuliaOpt/MathOptInterface.jl/pull/697,
- use `MOIB.full_bridge_optimizer` for the MOI testsets,
- call individual tests (not testsets with exclusions) when using direct `Optimizer`.

Still need to exlude tests for a variety of reasons (can't query vars by name, SCIP's SOC constraints make strong assumptions about var bounds, can't delete vars from constraints), but feel more future-proof w.r.t. to new tests being added to MOI :smile: 