### PR TITLE
Add Windows support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,30 @@
+environment:
+  matrix:
+  - julia_version: 1
+  SCIPOPTDIR: C:\scipoptdir
+
+platform:
+  - x64 # 64-bit
+
+branches:
+  only:
+    - master
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
+  - ps: wget http://scip.zib.de/download/release/SCIPOptSuite-6.0.1-win64-VS15.exe -outfile scipopt-installer.exe
+  - scipopt-installer.exe /S /D=%SCIPOPTDIR%
+
+build_script:
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
+
+test_script:
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ package should then work out of the box:
 
 If you [build SCIP from source](https://scip.zib.de/doc-6.0.1/html/CMAKE.php)
 you should set the environment variable `SCIPOPTDIR` to point the the
-**installation path**. That is, either `$SCIPOPTDIR/lib/libscip.so` or
-`$SCIPOPTDIR/bin/scip.dll` should exist.
+**installation path**. That is, either `$SCIPOPTDIR/lib/libscip.so`,
+`$SCIPOPTDIR/lib/libscip.dylib` or `$SCIPOPTDIR/bin/scip.dll` should exist,
+depending on your operating system.
 
 ## Setting Parameters
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ system. [SCIP's license](https://scip.zib.de/index.php#license) does not allow
 (automatic) redistribution, so please
 [download](https://scip.zib.de/index.php#download) and install it yourself.
 
-Currently, Linux and OS X are tested and supported. Contributions to supporting
-Windows are welcome.
+Currently, Linux, OS X and Windows are tested and supported.
 
 We recommend using one of the provided installers, e.g.,
 `SCIPOptSuite-6.0.1-Linux.deb` for systems based on Debian. Adding the SCIP.jl
@@ -40,7 +39,8 @@ package should then work out of the box:
 
 If you [build SCIP from source](https://scip.zib.de/doc-6.0.1/html/CMAKE.php)
 you should set the environment variable `SCIPOPTDIR` to point the the
-**installation path**. That is, `$SCIPOPTDIR/lib/libscip.so` should exist.
+**installation path**. That is, either `$SCIPOPTDIR/lib/libscip.so` or
+`$SCIPOPTDIR/bin/scip.dll` should exist.
 
 ## Setting Parameters
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,15 +6,19 @@ if isfile(depsfile)
 end
 
 function write_depsfile(path)
-    f = open(depsfile, "w")
-    println(f, "const libscip = \"$path\"")
-    close(f)
+    open(depsfile, "w") do f
+        print(f, "const libscip = ")
+        show(f, path)
+        println(f)
+    end
 end
 
 libname = if Sys.islinux()
     "libscip.so"
 elseif Sys.isapple()
     "libscip.dylib"
+elseif Sys.iswindows()
+    "scip.dll"
 else
     error("SCIP is currently not supported on \"$(Sys.KERNEL)\"")
 end
@@ -23,6 +27,7 @@ paths_to_try = []
 
 # prefer environment variable
 if haskey(ENV, "SCIPOPTDIR")
+    push!(paths_to_try, joinpath(ENV["SCIPOPTDIR"], "bin", libname))
     push!(paths_to_try, joinpath(ENV["SCIPOPTDIR"], "lib", libname))
 end
 


### PR DESCRIPTION
The package currently fails to build on Windows with the message `SCIP is currently not supported on "NT"`. This pull request fixes this by modifying `deps/build.jl` to search for the correct DLL. I have verified not only the package builds successfully with these changes, but also that all unit tests pass. 

The function `write_depsfile` needed to be modified because, on Windows, the `path` variable contains backslashes which need to be quoted.