### PR TITLE
Add user-friendly interface for statistics printing functionality.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,13 @@ CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
+[compat]
+CEnum = "^0.1.0"
+MathOptInterface = "^0.8.4"
+julia = "^1.0.0"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-[compat]
-CEnum = "^0.1.0"
-MathOptInterface = "^0.8.4"
-julia = "^1.0.0"

--- a/src/SCIP.jl
+++ b/src/SCIP.jl
@@ -1,5 +1,8 @@
 module SCIP
 
+# assorted utility functions
+include("util.jl")
+
 # load deps, version check
 include("init.jl")
 

--- a/src/managed_scip.jl
+++ b/src/managed_scip.jl
@@ -276,3 +276,56 @@ function add_indicator_constraint(mscip::ManagedSCIP, y, x, a, rhs)
     @SC SCIPaddCons(mscip, cons__[])
     return store_cons!(mscip, cons__)
 end
+
+# Transform SCIP C function name as follows:
+# 1. Remove leading "SCIP" part (drop the first four characters).
+# 2. Convert camel case to snake case.
+# For example, `SCIPprintStatusStatistics` becomes `print_status_statistics`.
+const STATISTICS_FUNCS = map(x -> Symbol(camel_case_to_snake_case(string(x)[5 : end])), SCIP_STATISTICS_FUNCS)
+
+for (scip_statistics_func, statistics_func) in zip(SCIP_STATISTICS_FUNCS, STATISTICS_FUNCS)
+    @eval begin
+        """
+            $($statistics_func)(mscip::ManagedSCIP)
+            $($statistics_func)(mscip::ManagedSCIP, file_descriptor::RawFD)
+            $($statistics_func)(mscip::ManagedSCIP, stream::Union{Base.Filesystem.File, IOStream})
+            $($statistics_func)(mscip::ManagedSCIP, filename::AbstractString)
+
+        Print statistics (calls `$($scip_statistics_func)`).
+
+        The one-argument version prints to standard output.
+
+        Note that the method that takes a stream only applies to synchronous
+        `File`s and `IOStream`s. In particular, it doesn't apply to `stdout`.
+        """
+        function $statistics_func end
+
+        function $statistics_func(mscip::ManagedSCIP)
+            ret = $scip_statistics_func(mscip, C_NULL)
+            ret !== nothing && @assert ret == SCIP_OKAY
+            return nothing
+        end
+
+        function $statistics_func(mscip::ManagedSCIP, file_descriptor::RawFD)
+            file = Libc.FILE(file_descriptor, "w")
+            try
+                ret = $scip_statistics_func(mscip, file)
+                ret !== nothing && @assert ret == SCIP_OKAY
+            finally
+                close(file)
+            end
+            return nothing
+        end
+
+        function $statistics_func(mscip::ManagedSCIP, stream::Union{Base.Filesystem.File, IOStream})
+            return $statistics_func(mscip, fd(stream))
+        end
+
+        function $statistics_func(mscip::ManagedSCIP, filename::AbstractString)
+            open(filename, write=true) do io
+                $statistics_func(mscip, RawFD(fd(io)))
+            end
+            return nothing
+        end
+    end
+end

--- a/src/managed_scip.jl
+++ b/src/managed_scip.jl
@@ -287,44 +287,14 @@ for (scip_statistics_func, statistics_func) in zip(SCIP_STATISTICS_FUNCS, STATIS
     @eval begin
         """
             $($statistics_func)(mscip::ManagedSCIP)
-            $($statistics_func)(mscip::ManagedSCIP, file_descriptor::RawFD)
-            $($statistics_func)(mscip::ManagedSCIP, stream::Union{Base.Filesystem.File, IOStream})
-            $($statistics_func)(mscip::ManagedSCIP, filename::AbstractString)
 
-        Print statistics (calls `$($scip_statistics_func)`).
-
-        The one-argument version prints to standard output.
-
-        Note that the method that takes a stream only applies to synchronous
-        `File`s and `IOStream`s. In particular, it doesn't apply to `stdout`.
+        Print statistics (calls `$($scip_statistics_func)`) to standard output.
         """
         function $statistics_func end
 
         function $statistics_func(mscip::ManagedSCIP)
             ret = $scip_statistics_func(mscip, C_NULL)
             ret !== nothing && @assert ret == SCIP_OKAY
-            return nothing
-        end
-
-        function $statistics_func(mscip::ManagedSCIP, file_descriptor::RawFD)
-            file = Libc.FILE(file_descriptor, "w")
-            try
-                ret = $scip_statistics_func(mscip, file)
-                ret !== nothing && @assert ret == SCIP_OKAY
-            finally
-                close(file)
-            end
-            return nothing
-        end
-
-        function $statistics_func(mscip::ManagedSCIP, stream::Union{Base.Filesystem.File, IOStream})
-            return $statistics_func(mscip, fd(stream))
-        end
-
-        function $statistics_func(mscip::ManagedSCIP, filename::AbstractString)
-            open(filename, write=true) do io
-                $statistics_func(mscip, RawFD(fd(io)))
-            end
             return nothing
         end
     end

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,0 +1,5 @@
+function camel_case_to_snake_case(x::AbstractString)
+    # from https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
+    s1 = replace(x, r"(.)([A-Z][a-z]+)" => s"\1_\2")
+    return lowercase(replace(s1, r"([a-z0-9])([A-Z])" => s"\1_\2"))
+end

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -138,3 +138,31 @@ include(wrap("expr_manual"))
 macro SC(ex)
     return :(@assert $(esc(ex)) == SCIP_OKAY)
 end
+
+const SCIP_STATISTICS_FUNCS = [
+    :SCIPprintStatusStatistics,
+    :SCIPprintTimingStatistics,
+    :SCIPprintOrigProblemStatistics,
+    :SCIPprintTransProblemStatistics,
+    :SCIPprintPresolverStatistics,
+    :SCIPprintConstraintStatistics,
+    :SCIPprintConstraintTimingStatistics,
+    :SCIPprintPropagatorStatistics,
+    :SCIPprintConflictStatistics,
+    :SCIPprintSeparatorStatistics,
+    :SCIPprintPricerStatistics,
+    :SCIPprintBranchruleStatistics,
+    :SCIPprintHeuristicStatistics,
+    :SCIPprintCompressionStatistics,
+    :SCIPprintLPStatistics,
+    :SCIPprintNLPStatistics,
+    :SCIPprintRelaxatorStatistics,
+    :SCIPprintTreeStatistics,
+    :SCIPprintRootStatistics,
+    :SCIPprintSolutionStatistics,
+    :SCIPprintConcsolverStatistics,
+    :SCIPprintBendersStatistics,
+    :SCIPprintStatistics,
+    :SCIPprintReoptStatistics,
+    :SCIPprintBranchingStatistics
+]

--- a/src/wrapper/manual_commons.jl
+++ b/src/wrapper/manual_commons.jl
@@ -37,7 +37,7 @@ const SCIP_EVENTTYPE_SYNC = UInt64(0x100000000)
 
 const PRIx64 = "llx"
 
-const FILE = Cvoid
+using Base.Libc: FILE
 
 const BMS_BLKMEM = Cvoid
 const BMS_BUFMEM = Cvoid

--- a/test/managed_scip.jl
+++ b/test/managed_scip.jl
@@ -92,3 +92,23 @@ end
         @test mscip.scip[] == C_NULL
     end
 end
+
+@testset "print statistics" begin
+    mscip = SCIP.ManagedSCIP()
+    SCIP.set_parameter(mscip, "display/verblevel", 0)
+
+    x = SCIP.add_variable(mscip)
+    y = SCIP.add_variable(mscip)
+    z = SCIP.add_variable(mscip)
+    c = SCIP.add_linear_constraint(mscip, [x, y], [2.0, 3.0], 1.0, 9.0)
+    SCIP.@SC SCIP.SCIPsolve(mscip)
+
+    @testset "$statistics_func" for statistics_func in map(x -> eval(:(SCIP.$x)), SCIP.STATISTICS_FUNCS)
+        mktempdir() do dir
+            filename = joinpath(dir, "statistics.txt")
+            @test !isfile(filename)
+            statistics_func(mscip, filename)
+            @test isfile(filename)
+        end
+    end
+end

--- a/test/managed_scip.jl
+++ b/test/managed_scip.jl
@@ -107,8 +107,17 @@ end
         mktempdir() do dir
             filename = joinpath(dir, "statistics.txt")
             @test !isfile(filename)
-            statistics_func(mscip, filename)
+            open(filename, write=true) do io
+                redirect_stdout(io) do
+                    statistics_func(mscip)
+                end
+            end
             @test isfile(filename)
+            if statistics_func == SCIP.print_statistics
+                # Ensure that at least `print_statistics` produces output
+                # (Not all statistics functions do for this simple model.)
+                @test filesize(filename) > 0
+            end
         end
     end
 end


### PR DESCRIPTION
Allows you to do e.g.

```julia
print_timing_statistics(mscip)
```

or

```julia
print_timing_statistics(mscip, filename)
```

The docstrings for these functions look like

```julia
help?> SCIP.print_timing_statistics
  SCIP.print_timing_statistics(mscip::ManagedSCIP)
  SCIP.print_timing_statistics(mscip::ManagedSCIP, file_descriptor::RawFD)
  SCIP.print_timing_statistics(mscip::ManagedSCIP, stream::Union{Base.Filesystem.File, IOStream})
  SCIP.print_timing_statistics(mscip::ManagedSCIP, filename::AbstractString)

  Print statistics (calls SCIP.SCIPprintTimingStatistics).

  The one-argument version prints to standard output.

  Note that the method that takes a stream only applies to synchronous Files and IOStreams. In particular, it doesn't apply to stdout.
```