### PR TITLE
update CI scripts to use SCIP 6.0.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ notifications:
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
-  - ps: wget http://scip.zib.de/download/release/SCIPOptSuite-6.0.1-win64-VS15.exe -outfile scipopt-installer.exe
+  - ps: wget http://scip.zib.de/download/release/SCIPOptSuite-6.0.2-win64-VS15.exe -outfile scipopt-installer.exe
   - scipopt-installer.exe /S /D=%SCIPOPTDIR%
 
 build_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
     - libblas3
     - libc6
     - libgcc1
-    - libgfortran4
+    - libgfortran3
     - libgmp10
     - libgsl2
     - liblapack3
@@ -30,8 +30,9 @@ addons:
     - zlib1g
 before_install:
   - export VERSION=6.0.2
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget http://scip.zib.de/download/release/SCIPOptSuite-$VERSION-Linux.deb; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo dpkg -i SCIPOptSuite-$VERSION-Linux.deb; fi
+  - export DEBFILE=SCIPOptSuite-$VERSION-Linux-Ub1604.deb
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget http://scip.zib.de/download/release/$DEBFILE; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo dpkg -i $DEBFILE ; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget http://scip.zib.de/download/release/scipoptsuite-$VERSION.tgz; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then tar -xf scipoptsuite-$VERSION.tgz && cd scipoptsuite-$VERSION; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mkdir build && cd build && cmake -D CMAKE_BUILD_TYPE=Release -D ZIMPL=OFF -D GCG=OFF -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX=../install ..; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 os:
   - linux
   - osx
-dist: xenial
+dist: bionic
 sudo: true
 julia:
   - 1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 os:
   - linux
   - osx
-dist: bionic
+dist: xenial
 sudo: true
 julia:
   - 1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ addons:
     - libblas3
     - libc6
     - libgcc1
-    - libgfortran3
+    - libgfortran4
     - libgmp10
     - libgsl2
     - liblapack3
     - libstdc++6
     - zlib1g
 before_install:
-  - export VERSION=6.0.1
+  - export VERSION=6.0.2
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget http://scip.zib.de/download/release/SCIPOptSuite-$VERSION-Linux.deb; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo dpkg -i SCIPOptSuite-$VERSION-Linux.deb; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget http://scip.zib.de/download/release/scipoptsuite-$VERSION.tgz; fi


### PR DESCRIPTION
Version 6.0.2 not released properly yet:

> Note that currently, the download of the SCIP Optimization Suite 6.0.2 is a beta version of our upcoming bugfix release.
